### PR TITLE
Skip all falsy values

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -23,8 +23,8 @@ async function prompts(questions = [], { onSubmit = noop, onCancel = noop } = {}
       prompt[key] = typeof value === 'function' ? await value(answer, { ...answers }, prompt) : value;
     }
 
-    // skip questins of type null
-    if (prompt.type === null) continue;
+    // skip if type is a falsy value
+    if (!prompt.type) continue;
 
     if (!types.hasOwnProperty(prompt.type)) {
       throw new Error(`prompt type ${prompt.type} not defined`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prompts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Lightweight, beautiful and user-friendly prompts",
   "homepage": "https://github.com/terkelg/prompts",
   "repository": "terkelg/prompts",


### PR DESCRIPTION
Before the prompter only skipped values of type `null`.