### PR TITLE
Fix: Correctly highlight initial Select value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.DS_Store
 node_modules
+.DS_Store
+*.lock

--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -13,7 +13,7 @@ class SelectPrompt extends Prompt {
     super();
 
     this.msg = message;
-    this.cursor = cursor;
+    this.cursor = initial || cursor;
 
     this.values = choices;
     this.value = choices[initial].value;


### PR DESCRIPTION
Both `initial` and `cursor` are `0` by default and index-based. Use the initial value to set the initial cursor position, which fixes the formatting.

Also added `*.lock` to gitignore to keep all yarn & package lock files out of repo~

---

Closes #24 