### PR TITLE
Add "engines" config

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "devDependencies": {
     "tap-spec": "^4.1.1",
     "tape": "^4.8.0"
+  },
+  "engines": {
+    "node": ">= 8"
   }
 }


### PR DESCRIPTION
This will make `npm` throw an error immediately if a user tries to run `prompts` in an older Node version that doesn't support `async` functions.

> Technically, this could be `>= 7.4` but there's no real reason to do this haha. If someone complains, we can step _down_ without being a breaking change. Moving _up_ the minimum is always a breaking, major change -- so better to just start with 8.x now~!

This would likely have prevented #18 and #32, and any futures to come.