### PR TITLE
Refactor Prompts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const noop = () => {};
 async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
   const answers = {};
   questions = [].concat(questions);
-  let answer, question, quit, name, key;
+  let answer, question, quit, name, type, key;
   let MAP = prompt._map || {};
 
   for (question of questions) {
@@ -33,14 +33,14 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
     }
 
     // skip if type is a falsy value
-    if (!question.type) continue;
+    if (!(type=question.type)) continue;
 
-    if (!prompts.hasOwnProperty(question.type)) {
-      throw new Error(`prompt type ${question.type} not defined`);
+    if (prompts[type] === void 0) {
+      throw new Error(`prompt type (${type}) is not defined`);
     }
 
     try {
-      answer = await prompts[question.type](question);
+      answer = await prompts[type](question);
       answers[name] = answer = question.format ? question.format(answer, answers) : answer;
       quit = onSubmit(question, answer);
     } catch (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
 const prompts = require('./prompts');
 
-const toArray = val => (Array.isArray(val) ? val : val == null ? [] : [val]);
 const ignore = ['suggest', 'format', 'onState'];
 const noop = () => {};
 
@@ -13,7 +12,7 @@ const noop = () => {};
  */
 async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
   const answers = {};
-  questions = toArray(questions);
+  questions = [].concat(questions);
   let answer, question, quit, name, key;
   let MAP = prompt._map || {};
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
   let MAP = prompt._map || {};
 
   for (question of questions) {
-    name = question.name;
+    ({ name, type } = question);
 
     if (MAP[name] !== void 0) {
       answers[name] = MAP[name];
@@ -33,7 +33,7 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
     }
 
     // skip if type is a falsy value
-    if (!(type=question.type)) continue;
+    if (!type) continue;
 
     if (prompts[type] === void 0) {
       throw new Error(`prompt type (${type}) is not defined`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,10 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
       continue; // take val & run
     }
 
+    if (typeof question.message !== 'string') {
+      throw new Error('prompt message is required');
+    }
+
     // if property is a function, invoke it unless it's ignored
     for (key in question) {
       if (ignore.includes(key)) continue;

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -127,7 +127,7 @@ function select(args) {
  * @returns {Promise} Promise with user input
  */
 function multiselect(args) {
-  if (!Array.isArray(args.choices)) throw new Error('choices array is required');
+  args.choices = [].concat(args.choices || []);
   const toSelected = items => items.filter(item => item.selected).map(item => item.value);
   return toPrompt('MultiselectPrompt', args, {
     onAbort: toSelected,
@@ -146,8 +146,8 @@ function multiselect(args) {
  * @returns {Promise} Promise with user input
  */
 function autocomplete(args) {
-  if (!Array.isArray(args.choices)) throw new Error('choices array is required');
   args.suggest = args.suggest || byTitle;
+  args.choices = [].concat(args.choices || []);
   return toPrompt('AutocompletePrompt', args);
 }
 

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -149,7 +149,7 @@ function multiselect(args) {
  * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function autocomplete({ message, choices, suggest, limit, style, onState = noop }) {
+function autocomplete(args) {
   if (!Array.isArray(args.choices)) throw new Error('choices array is required');
   args.suggest = args.suggest || byTitle;
   return toPrompt('AutocompletePrompt', args);

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -4,10 +4,6 @@ const el = require('./elements');
 const noop = v => v;
 
 function toPrompt(type, args, opts={}) {
-  if (typeof args.message !== 'string') {
-    throw new Error('message is required');
-  }
-
   return new Promise((res, rej) => {
     const p = new el[type](args);
     const onAbort = opts.onAbort || noop;

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,186 +1,164 @@
 'use strict';
 
 const el = require('./elements');
-const noop = () => {};
+const noop = v => v;
+
+function toPrompt(type, args, opts={}) {
+  if (typeof args.message !== 'string') {
+    throw new Error('message is required');
+  }
+
+  return new Promise((res, rej) => {
+    const p = new el[type](args);
+    const onAbort = opts.onAbort || noop;
+    const onSubmit = opts.onSubmit || noop;
+    p.on('state', args.onState || noop);
+    p.on('submit', x => res(onSubmit(x)));
+    p.on('abort', x => rej(onAbort(x)));
+  });
+}
 
 /**
  * Text prompt
- * @param {string} message Prompt message to display
- * @param {string} [initial] Default string value
- * @param {string} [style="default"] Render style ('default', 'password', 'invisible')
- * @param {function} [onState] On state change callback
+ * @param {string} args.message Prompt message to display
+ * @param {string} [args.initial] Default string value
+ * @param {string} [args.style="default"] Render style ('default', 'password', 'invisible')
+ * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function text({ message, initial, style, onState = noop }) {
-  if (typeof message !== 'string') throw new Error('message is required');
-  return new Promise((resolve, reject) => {
-    const p = new el.TextPrompt({ message, initial, style });
-    p.on('submit', resolve);
-    p.on('abort', reject);
-    p.on('state', onState)
-  });
+function text(args) {
+  return toPrompt('TextPrompt', args);
 }
 
 /**
  * Password prompt with masked input
- * @param {string} message Prompt message to display
- * @param {string} [initial] Default string value
- * @param {function} [onState] On state change callback
+ * @param {string} args.message Prompt message to display
+ * @param {string} [args.initial] Default string value
+ * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  *
  */
-const password = ({ message, initial, onState }) => text({ message, initial, onState, style: 'password' });
+function password(args) {
+  args.style = 'password';
+  return text(args);
+}
 
 /**
  * Prompt where input is invisible, like sudo
- * @param {string} message Prompt message to display
- * @param {string} [initial] Default string value
- * @param {function} [onState] On state change callback
+ * @param {string} opts.message Prompt message to display
+ * @param {string} [opts.initial] Default string value
+ * @param {function} [opts.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-const invisible = ({ message, initial, onState }) => text({ message, initial, onState, style: 'invisible' });
+function invisible(opts) {
+  opts.style = 'invisible';
+  return text(opts);
+}
 
 /**
  * Number prompt
- * @param {string} message Prompt message to display
- * @param {number} initial Default number value
- * @param {number} [max] Max value
- * @param {number} [min] Min value
- * @param {string} [style="default"] Render style ('default', 'password', 'invisible')
- * @param {function} [onState] On state change callback
+ * @param {string} args.message Prompt message to display
+ * @param {number} args.initial Default number value
+ * @param {number} [args.max] Max value
+ * @param {number} [args.min] Min value
+ * @param {string} [args.style="default"] Render style ('default', 'password', 'invisible')
+ * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function number({ message, initial, max, min, style, onState = noop }) {
-  if (typeof message !== 'string') throw new Error('message is required');
-  return new Promise((resolve, reject) => {
-    const p = new el.NumberPrompt({ message, initial, max, min, style });
-    p.on('submit', resolve);
-    p.on('abort', reject);
-    p.on('state', onState)
-  });
+function number(args) {
+  return toPrompt('NumberPrompt', args);
 }
 
 /**
  * Classic yes/no prompt
- * @param {string} message Prompt message to display
- * @param {boolean} [initial=false] Default value
- * @param {function} [onState] On state change callback
+ * @param {string} args.message Prompt message to display
+ * @param {boolean} [args.initial=false] Default value
+ * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function confirm({ message, initial, onState = noop }) {
-  if (typeof message !== 'string') throw new Error('message is required');
-  return new Promise((resolve, reject) => {
-    const p = new el.ConfirmPrompt({ message, initial });
-    p.on('submit', resolve);
-    p.on('abort', reject);
-    p.on('state', onState);
-  });
+function confirm(args) {
+  return toPrompt('ConfirmPrompt', args);
 }
 
 /**
  * List prompt, split intput string by `seperator`
- * @param {string} message Prompt message to display
- * @param {string} [initial] Default string value
- * @param {string} [style="default"] Render style ('default', 'password', 'invisible')
- * @param {string} [separator] String separator
- * @param {function} [onState] On state change callback
+ * @param {string} args.message Prompt message to display
+ * @param {string} [args.initial] Default string value
+ * @param {string} [args.style="default"] Render style ('default', 'password', 'invisible')
+ * @param {string} [args.separator] String separator
+ * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input, in form of an `Array`
  */
-function list({ message, initial, style, separator = ',', onState = noop }) {
-  if (typeof message !== 'string') throw new Error('message is required');
-  return new Promise((resolve, reject) => {
-    const p = new el.TextPrompt({ message, initial, style });
-    p.on('submit', str => resolve(str.split(separator).map(s => s.trim())));
-    p.on('abort', reject);
-    p.on('state', onState);
+function list(args) {
+  const sep = args.separator || ',';
+  return toPrompt('TextPrompt', args, {
+    onSubmit: str => str.split(sep).map(s => s.trim())
   });
 }
 
 /**
  * Toggle/switch prompt
- * @param {string} message Prompt message to display
- * @param {boolean} [initial=false] Default value
- * @param {string} [active="on"] Text for `active` state
- * @param {string} [inactive="off"] Text for `inactive` state
- * @param {function} [onState] On state change callback
+ * @param {string} args.message Prompt message to display
+ * @param {boolean} [args.initial=false] Default value
+ * @param {string} [args.active="on"] Text for `active` state
+ * @param {string} [args.inactive="off"] Text for `inactive` state
+ * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function toggle({ message, initial, active, inactive, onState = noop }) {
-  if (typeof message !== 'string') throw new Error('message is required');
-  return new Promise((resolve, reject) => {
-    const p = new el.TogglePrompt({ message, initial, active, inactive });
-    p.on('submit', resolve);
-    p.on('abort', reject);
-    p.on('state', onState);
-  });
+function toggle(args) {
+  return toPrompt('TogglePrompt', args);
 }
 
 /**
  * Interactive select prompt
- * @param {string} message Prompt message to display
- * @param {Array} choices Array of choices objects `[{ title, value }, ...]`
- * @param {number} [initial] Index of default value
- * @param {function} [onState] On state change callback
+ * @param {string} arr.message Prompt message to display
+ * @param {Array} arr.choices Array of choices objects `[{ title, value }, ...]`
+ * @param {number} [arr.initial] Index of default value
+ * @param {function} [arr.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function select({ message, choices, initial, onState = noop }) {
-  if (typeof message !== 'string') throw new Error('message is required');
-  return new Promise((resolve, reject) => {
-    const p = new el.SelectPrompt({ message, choices, initial });
-    p.on('submit', resolve);
-    p.on('abort', reject);
-    p.on('state', onState);
+function select(args) {
+  return toPrompt('SelectPrompt', args);
+}
+
+/**
+ * Interactive multi-select prompt
+ * @param {string} args.message Prompt message to display
+ * @param {Array} args.choices Array of choices objects `[{ title, value, [selected] }, ...]`
+ * @param {number} [args.max] Max select
+ * @param {string} [args.hint] Hint to display user
+ * @param {function} [args.onState] On state change callback
+ * @returns {Promise} Promise with user input
+ */
+function multiselect(args) {
+  if (!Array.isArray(args.choices)) throw new Error('choices array is required');
+  const toSelected = items => items.filter(item => item.selected).map(item => item.value);
+  return toPrompt('MultiselectPrompt', args, {
+    onAbort: toSelected,
+    onSubmit: toSelected
   });
 }
 
 /**
  * Interactive multi-select prompt
- * @param {string} message Prompt message to display
- * @param {Array} choices Array of choices objects `[{ title, value, [selected] }, ...]`
- * @param {number} [max] Max select
- * @param {string} [hint] Hint to display user
- * @param {function} [onState] On state change callback
- * @returns {Promise} Promise with user input
- */
-function multiselect({ message, choices, max, hint, onState = noop }) {
-  if (typeof message !== 'string') throw new Error('message is required');
-  if (!Array.isArray(choices)) throw new Error('choices array is required');
-
-  return new Promise((resolve, reject) => {
-    const p = new el.MultiselectPrompt({ message, choices, max, hint });
-    const selected = items => items.filter(item => item.selected).map(item => item.value);
-    p.on('submit', items => resolve(selected(items)));
-    p.on('abort', items => reject(selected(items)));
-    p.on('state', onState);
-  });
-}
-
-/**
- * Interactive multi-select prompt
- * @param {string} message Prompt message to display
- * @param {Array} choices Array of auto-complete choices objects `[{ title, value }, ...]`
- * @param {Function} [suggest] Function to filter results based on user input. Defaults to stort by `title`
- * @param {number} [limit=10] Max number of results to show
- * @param {string} [style="default"] Render style ('default', 'password', 'invisible')
- * @param {function} [onState] On state change callback
+ * @param {string} args.message Prompt message to display
+ * @param {Array} args.choices Array of auto-complete choices objects `[{ title, value }, ...]`
+ * @param {Function} [args.suggest] Function to filter results based on user input. Defaults to sort by `title`
+ * @param {number} [args.limit=10] Max number of results to show
+ * @param {string} [args.style="default"] Render style ('default', 'password', 'invisible')
+ * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
 function autocomplete({ message, choices, suggest, limit, style, onState = noop }) {
-  if (typeof message !== 'string') throw new Error('message is required');
-  if (!Array.isArray(choices)) throw new Error('choices array is required');
-  const suggestByTitle = (input, choices) =>
-    Promise.resolve(
-      choices.filter(
-        item => item.title.slice(0, input.length).toLowerCase() === input.toLowerCase()
-      )
-    );
-  suggest = suggest ? suggest : suggestByTitle;
-  return new Promise((resolve, reject) => {
-    const p = new el.AutocompletePrompt({ message, choices, suggest, limit, style });
-    p.on('submit', resolve);
-    p.on('abort', reject);
-    p.on('state', onState);
-  });
+  if (!Array.isArray(args.choices)) throw new Error('choices array is required');
+  args.suggest = args.suggest || byTitle;
+  return toPrompt('AutocompletePrompt', args);
+}
+
+function byTitle(input, choices) {
+  return Promise.resolve(
+    choices.filter(item => item.title.slice(0, input.length).toLowerCase() === input.toLowerCase())
+  );
 }
 
 module.exports = {

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const $ = exports;
 const el = require('./elements');
 const noop = v => v;
 
@@ -22,9 +22,7 @@ function toPrompt(type, args, opts={}) {
  * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function text(args) {
-  return toPrompt('TextPrompt', args);
-}
+$.text = args => toPrompt('TextPrompt', args);
 
 /**
  * Password prompt with masked input
@@ -34,22 +32,22 @@ function text(args) {
  * @returns {Promise} Promise with user input
  *
  */
-function password(args) {
+$.password = args => {
   args.style = 'password';
-  return text(args);
-}
+  return $.text(args);
+};
 
 /**
  * Prompt where input is invisible, like sudo
- * @param {string} opts.message Prompt message to display
- * @param {string} [opts.initial] Default string value
- * @param {function} [opts.onState] On state change callback
+ * @param {string} args.message Prompt message to display
+ * @param {string} [args.initial] Default string value
+ * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function invisible(opts) {
-  opts.style = 'invisible';
-  return text(opts);
-}
+$.invisible = args => {
+  args.style = 'invisible';
+  return $.text(args);
+};
 
 /**
  * Number prompt
@@ -61,9 +59,7 @@ function invisible(opts) {
  * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function number(args) {
-  return toPrompt('NumberPrompt', args);
-}
+$.number = args => toPrompt('NumberPrompt', args);
 
 /**
  * Classic yes/no prompt
@@ -72,9 +68,7 @@ function number(args) {
  * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function confirm(args) {
-  return toPrompt('ConfirmPrompt', args);
-}
+$.confirm = args => toPrompt('ConfirmPrompt', args);
 
 /**
  * List prompt, split intput string by `seperator`
@@ -85,12 +79,12 @@ function confirm(args) {
  * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input, in form of an `Array`
  */
-function list(args) {
+$.list = args => {
   const sep = args.separator || ',';
   return toPrompt('TextPrompt', args, {
     onSubmit: str => str.split(sep).map(s => s.trim())
   });
-}
+};
 
 /**
  * Toggle/switch prompt
@@ -101,9 +95,7 @@ function list(args) {
  * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function toggle(args) {
-  return toPrompt('TogglePrompt', args);
-}
+$.toggle = args => toPrompt('TogglePrompt', args);
 
 /**
  * Interactive select prompt
@@ -113,9 +105,7 @@ function toggle(args) {
  * @param {function} [arr.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function select(args) {
-  return toPrompt('SelectPrompt', args);
-}
+$.select = args => toPrompt('SelectPrompt', args);
 
 /**
  * Interactive multi-select prompt
@@ -126,14 +116,18 @@ function select(args) {
  * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function multiselect(args) {
+$.multiselect = args => {
   args.choices = [].concat(args.choices || []);
   const toSelected = items => items.filter(item => item.selected).map(item => item.value);
   return toPrompt('MultiselectPrompt', args, {
     onAbort: toSelected,
     onSubmit: toSelected
   });
-}
+};
+
+const byTitle = (input, choices) => Promise.resolve(
+  choices.filter(item => item.title.slice(0, input.length).toLowerCase() === input.toLowerCase())
+);
 
 /**
  * Interactive multi-select prompt
@@ -145,27 +139,8 @@ function multiselect(args) {
  * @param {function} [args.onState] On state change callback
  * @returns {Promise} Promise with user input
  */
-function autocomplete(args) {
+$.autocomplete = args => {
   args.suggest = args.suggest || byTitle;
   args.choices = [].concat(args.choices || []);
   return toPrompt('AutocompletePrompt', args);
-}
-
-function byTitle(input, choices) {
-  return Promise.resolve(
-    choices.filter(item => item.title.slice(0, input.length).toLowerCase() === input.toLowerCase())
-  );
-}
-
-module.exports = {
-  text,
-  password,
-  invisible,
-  number,
-  confirm,
-  list,
-  toggle,
-  select,
-  multiselect,
-  autocomplete
 };


### PR DESCRIPTION
We were destructuring all prompt-objects, only to reassemble them in nearly the same way. While this made it a little more legible in some ways, it also added a lot of noise. 

Looking at the underling `elements`, _they_ were also picking out the keys that they cared about, which meant that we could safely pass everything down to them. In most cases, hardly anything from the `args` is accessory anyway -- it's pretty much just the `onState` key that gets discarded.

> Moving forward, we can even consolidate some of the Elements' construction, but definitely not a priority. 

Anyway, after clearing up a bunch of the pattern matching, it was pretty clear that our `prompts.js` was doing the same thing for every type, with a tiny exception here n' there.

The entire file is now 44 lines of code, plus 102 lines of whitespace and docs 😆 

Also, I moved the `message` checking into the main loop. The errors were being swallowed by the `onCancel` handler, immediately skipping the `prompt` instead. I also converted the `throw` for ensuring `choices` was an Array into the action of just ensuring it's an Array. It'll be pretty obvious that something's wrong when there are 0 choices 😉 

TLDR:

* Merge all `prompts` types to build from single function
* Throw Error from main loop if no `message` instead of silent skip
* Ensure `choices` is always an Array instead of silent skip
* Moderate rewrites, nothing major