### PR TITLE
add support for node 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": "6"
+      }
+    }],
+    "stage-2"
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "targets": {
         "node": "6"
       }
-    }],
-    "stage-2"
-  ]
+    }]
+  ],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+script:
+ - npm run build
+ - npm test
 node_js:
   - "8"
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - 8
+  - "8"
+  - "6"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+module.exports =
+  parseInt(process.versions.node, 10) < 8
+    ? require('./dist/index.js')
+    : require('./lib/index.js');

--- a/package.json
+++ b/package.json
@@ -4,17 +4,19 @@
   "description": "Lightweight, beautiful and user-friendly prompts",
   "homepage": "https://github.com/terkelg/prompts",
   "repository": "terkelg/prompts",
-  "main": "lib/index.js",
+  "main": "index.js",
   "author": {
     "name": "Terkel Gjervig",
     "email": "terkel@terkel.com",
     "url": "https://terkel.com"
   },
   "files": [
-    "lib"
+    "lib",
+    "dist"
   ],
   "scripts": {
     "start": "node lib/index.js",
+    "build": "babel lib -d dist",
     "test": "tape test/*.js | tap-spec"
   },
   "keywords": [
@@ -31,10 +33,13 @@
     "sisteransi": "^0.1.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-stage-2": "^6.24.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.8.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "lib",
-    "dist"
+    "dist",
+    "index.js"
   ],
   "scripts": {
     "start": "node lib/index.js",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "babel-preset-stage-2": "^6.24.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.8.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@
 $ npm install --save prompts
 ```
 
-> This package uses async/await and requires Node.js 7.6
+> This package supports Node 6 and above
 
 ![split](https://github.com/terkelg/prompts/raw/master/media/split.png)
 

--- a/test/prompts.js
+++ b/test/prompts.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('tape');
-const prompt = require('../lib');
+const prompt = require('../');
 const { prompts } = prompt;
 
 test('basics', t => {
@@ -36,18 +36,21 @@ test('prompts', t => {
   t.equal(Object.keys(prompts).length, types.length, 'all prompts are exported');
 });
 
-test('injects', async t => {
+test('injects', t => {
   let obj = { a:1, b:2, c:3 };
   prompt.inject(obj);
   t.same(prompt._map, obj, 'injects key:val object of answers');
 
-  let foo = await prompt({ name:'a' });
-  t.same(foo, { a:1 }, 'immediately returns object with injected answer');
-  t.same(prompt._map, { b:2, c:3 }, 'deletes the `a` key from internal map');
-
-  let bar = await prompt([{ name:'b' }, { name:'c' }]);
-  t.same(bar, { b:2, c:3 }, 'immediately handles two prompts at once');
-  t.same(prompt._map, {}, 'leaves behind empty internal mapping when exhausted');
-
-  t.end();
+  prompt({ name:'a' })
+    .then(foo => {
+      t.same(foo, { a:1 }, 'immediately returns object with injected answer');
+      t.same(prompt._map, { b:2, c:3 }, 'deletes the `a` key from internal map');
+    
+      prompt([{ name:'b' }, { name:'c' }])
+        .then(bar => {
+          t.same(bar, { b:2, c:3 }, 'immediately handles two prompts at once');
+          t.same(prompt._map, {}, 'leaves behind empty internal mapping when exhausted');
+          t.end();
+    })
+  })
 })


### PR DESCRIPTION
## Summary

#### This PR Fixes #64 and adds node 6 support

* Add a build script that runs `babel` and transpile all files from `lib` to `dist`
* Add `dist` to `.gitignore`
* Add `dist` & `index.js` to the files array in `package.json` so they will be available on next publish.
* Add an `index.js` file on the root, which routes between `lib` and `dist` according to the user's Node version.
* Configure Travis to run on both Node 6 and 8
* Promisified a part of the tests. I started by using `babel-register` but then I realized that I couldn't test that they actually run on node 6.
* Update readme

## Test Plan
All tests are passing on CI when using Node 6