### PR TITLE
`inject` function improvements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,16 +14,9 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
   const answers = {};
   questions = [].concat(questions);
   let answer, question, quit, name, type;
-  let MAP = prompt._map || {};
 
   for (question of questions) {
     ({ name, type } = question);
-
-    if (MAP[name] !== void 0) {
-      answers[name] = MAP[name];
-      delete MAP[name];
-      continue; // take val & run
-    }
 
     // if property is a function, invoke it unless it's a special function
     for (let key in question) {
@@ -47,7 +40,8 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
     }
 
     try {
-      answer = await prompts[type](question);
+      // Get the injected answer if there is one or prompt the user
+      answer = prompt._injected ? getInjectedAnswer(prompt._injected) : await prompts[type](question);
       answers[name] = answer = question.format ? await question.format(answer, answers) : answer;
       quit = await onSubmit(question, answer, answers);
     } catch (err) {
@@ -60,11 +54,17 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
   return answers;
 }
 
-function inject(obj) {
-  prompt._map = prompt._map || {};
-  for (let k in obj) {
-    prompt._map[k] = obj[k];
-  }
+function getInjectedAnswer(injected) {
+  const answer = injected.shift();
+    if (answer instanceof Error) {
+      throw answer;
+    }
+
+    return answer;
+}
+
+function inject(answers) {
+  prompt._injected = (prompt._injected || []).concat(answers)
 }
 
 module.exports = Object.assign(prompt, { prompt, prompts, inject });

--- a/readme.md
+++ b/readme.md
@@ -213,32 +213,42 @@ let response = await prompts(questions, { onCancel });
 Type: `Function`<br>
 
 Programmatically inject responses. This enables you to prepare the responses ahead of time.
-If any injected values are found the prompt is immediately resolved with the injected value.
+If any injected value is found the prompt is immediately resolved with the injected value.
 This feature is intended for testing only.
 
 #### values
 
-Type: `Object`
+Type: `Array`
 
-Object with key/values to inject. Resolved values are deleted from the internal inject object.
+Array with values to inject. Resolved values are removed from the internal inject array.
+Each value can be an array of values in order to provide answers for a question asked multiple times.
+If a value is an instance of `Error` it will simulate the user cancelling/exiting the prompt.
 
 **Example:**
 ```js
 const prompts = require('prompts');
 
-prompts.inject({ q1: 'a1', q2: 'q2' });
+prompts.inject([ '@terkelg', ['#ff0000', '#0000ff'] ]);
+
 let response = await prompts({
   type: 'text',
-  name: 'q1',
-  message: 'Question 1'
+  name: 'twitter',
+  message: `What's your twitter handle?`
+},
+{
+  type: 'multiselect',
+  name: 'color',
+  message: 'Pick colors',
+  choices: [
+      { title: 'Red', value: '#ff0000' },
+      { title: 'Green', value: '#00ff00' },
+      { title: 'Blue', value: '#0000ff' }
+    ],
 });
 
-// => { q1: 'a1' }
+// => { twitter: 'terkelg', color: [ '#ff0000', '#0000ff' ] }
 
 ```
-
-> When `q1` resolves it's wiped. `q2` doesn't resolve and is left untouched.
-
 
 ![split](https://github.com/terkelg/prompts/raw/master/media/split.png)
 

--- a/test/prompts.js
+++ b/test/prompts.js
@@ -37,19 +37,19 @@ test('prompts', t => {
 });
 
 test('injects', t => {
-  let obj = { a:1, b:2, c:3 };
-  prompt.inject(obj);
-  t.same(prompt._map, obj, 'injects key:val object of answers');
+  let injected = [ 1, 2, 3 ];
+  prompt.inject(injected);
+  t.same(prompt._injected, injected, 'injects array of answers');
 
-  prompt({ name:'a' })
+  prompt({ type: 'text', name:'a', message: 'a message' })
     .then(foo => {
       t.same(foo, { a:1 }, 'immediately returns object with injected answer');
-      t.same(prompt._map, { b:2, c:3 }, 'deletes the `a` key from internal map');
-    
-      prompt([{ name:'b' }, { name:'c' }])
+      t.same(prompt._injected, [ 2, 3 ], 'deletes the first answer from internal array');
+
+      prompt([{ type: 'text', name:'b', message: 'b message' }, { type: 'text', name:'c', message: 'c message' }])
         .then(bar => {
           t.same(bar, { b:2, c:3 }, 'immediately handles two prompts at once');
-          t.same(prompt._map, {}, 'leaves behind empty internal mapping when exhausted');
+          t.same(prompt._injected, [], 'leaves behind empty internal array when exhausted');
           t.end();
     })
   })


### PR DESCRIPTION
This PR provide 2 improvements to the [inject](https://github.com/terkelg/prompts#injectvalues) function:
- Allow to define multiple answer for the same question, which allow to support repeated questions
- Trigger all the callback that a non inject answer would which allow to test functionalities such as `onSubmit` or `format`

Here is an example of a prompt and it's associated test:
```js
const prompts = require('prompts');
const delay = require('delay');

const questions = [{
    type: 'number',
    name: 'price',
    message: 'Guess the price',
    format: val => Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(val)
}];
const answers = [];

const ask = async questions => prompts(questions, {
   onSubmit: async (prompt, response) => {
    if (prompt.name === 'price' && !(await checkPriceOnServer(response))) {
      console.log('You guessed wrong...try again!');
      // Ask again and collect answer
      answers.push(await ask(questions));
      return;
    }
    console.log('You guessed right!');
  },
    onCancel: async prompt => {
      if (prompt.name === 'price') {
        console.log('Don\'t stop prompting until you guess right...');
        // Ask again and collect answer
        answers.push(await ask(questions));
        return true;
      }
    }
})

async function checkPriceOnServer(price) {
  // Simulate async response
  return delay(1000).then(() => price === '$10.00');
}

module.exports = async () => {
  await ask(questions);
  return Object.assign(...answers.reverse());
};
```
```js
const prompts = require('prompts');
const prompter = require('./prompter');
prompts.inject({price: [5, new Error('Hit Ctrl+C'), 10]});
prompter().then(console.log);

// => You guessed wrong...try again!
// => Don't stop prompting until you guess right...
// => You guessed right!
// => { price: '$10.00' }
```