### PR TITLE
Added `disabled` option for choices (Fixes #96)

### DIFF
--- a/example.js
+++ b/example.js
@@ -46,6 +46,7 @@ const { prompt } = require('./');
             choices: [
               { title: 'Red', value: '#ff0000' }, 
               { title: 'Green', value: '#00ff00' },
+              { title: 'Yellow', value: '#ffff00', disabled: true },
               { title: 'Blue', value: '#0000ff' }
             ]
         },
@@ -55,7 +56,8 @@ const { prompt } = require('./');
             message: 'Pick colors',
             choices: [
                 { title: 'Red', value: '#ff0000' },
-                { title: 'Green', value: '#00ff00' },
+                { title: 'Green', value: '#00ff00', disabled: true },
+                { title: 'Yellow', value: '#ffff00' },
                 { title: 'Blue', value: '#0000ff' }
             ]
         },

--- a/lib/elements/multiselect.js
+++ b/lib/elements/multiselect.js
@@ -22,6 +22,7 @@ class MultiselectPrompt extends Prompt {
     this.msg = opts.message;
     this.cursor = opts.cursor || 0;
     this.hint = opts.hint || '- Space to select. Return to submit';
+    this.warn = opts.warn || '- This option is disabled';
     this.maxChoices = opts.max;
     this.value = opts.choices.map(v => Object.assign({ title: v.value, selected: false }, v));
     this.clear = clear('');
@@ -100,7 +101,7 @@ class MultiselectPrompt extends Prompt {
     if (v.selected) {
       v.selected = false;
       this.render();
-    } else if (this.value.filter(e => e.selected).length >= this.maxChoices) {
+    } else if (v.disabled || this.value.filter(e => e.selected).length >= this.maxChoices) {
       return this.bell();
     } else {
       v.selected = true;
@@ -120,7 +121,8 @@ class MultiselectPrompt extends Prompt {
       style.symbol(this.done, this.aborted),
       color.bold(this.msg),
       style.delimiter(false),
-      this.done ? selected : color.gray(this.hint)
+      this.done ? selected : this.value[this.cursor].disabled
+                ? color.yellow(this.warn) : color.gray(this.hint)
     ].join(' ');
 
     // print choices
@@ -129,12 +131,12 @@ class MultiselectPrompt extends Prompt {
       prompt +=
         '\n' +
         this.value
-          .map(
-            (v, i) =>
-              (v.selected ? color.green(figures.tick) : ' ') +
-              ' ' +
-              (c === i ? color.cyan.underline(v.title) : v.title)
-          )
+          .map((v, i) => {
+            let title;
+            if (v.disabled) title = c === i ? color.gray.underline(v.title) : color.strikethrough.gray(v.title);
+            else title = c === i ? color.cyan.underline(v.title) : v.title;
+            return (v.selected ? color.green(figures.tick) : ' ') + ' ' + title
+          })
           .join('\n');
     }
 

--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -20,6 +20,7 @@ class SelectPrompt extends Prompt {
     super(opts);
     this.msg = opts.message;
     this.hint = opts.hint || '- Use arrow-keys. Return to submit.';
+    this.warn = opts.warn || '- This option is disabled';
     this.cursor = opts.initial || 0;
     this.values = opts.choices || [];
     this.value = opts.choices[this.cursor].value;
@@ -48,12 +49,15 @@ class SelectPrompt extends Prompt {
   }
 
   submit() {
-    this.done = true;
-    this.aborted = false;
-    this.fire();
-    this.render();
-    this.out.write('\n');
-    this.close();
+    if (!this.selection.disabled) {
+      this.done = true;
+      this.aborted = false;
+      this.fire();
+      this.render();
+      this.out.write('\n');
+      this.close();
+    } else
+      this.bell();
   }
 
   first() {
@@ -87,6 +91,10 @@ class SelectPrompt extends Prompt {
     if (c === ' ') return this.submit();
   }
 
+  get selection() {
+    return this.values[this.cursor];
+  }
+
   render(first) {
     if (first) this.out.write(cursor.hide);
     else this.out.write(erase.lines(this.values.length + 1));
@@ -96,7 +104,8 @@ class SelectPrompt extends Prompt {
         style.symbol(this.done, this.aborted),
         color.bold(this.msg),
         style.delimiter(false),
-        this.done ? this.values[this.cursor].title : color.gray(this.hint)
+        this.done ? this.selection.title : this.selection.disabled
+                  ? color.yellow(this.warn) : color.gray(this.hint)
       ].join(' '));
 
     // Print choices
@@ -105,8 +114,14 @@ class SelectPrompt extends Prompt {
         '\n' +
           this.values
             .map((v, i) => {
-              let title = this.cursor === i ? color.cyan.underline(v.title) : v.title;
-              let prefix = this.cursor === i ? color.cyan(figures.pointer) + ' ' : '  ';
+              let title, prefix;
+              if (v.disabled) {
+                title = this.cursor === i ? color.gray.underline(v.title) : color.strikethrough.gray(v.title);
+                prefix = this.cursor === i ? color.bold.gray(figures.pointer) + ' ' : '  ';
+              } else {
+                title = this.cursor === i ? color.cyan.underline(v.title) : v.title;
+                prefix = this.cursor === i ? color.cyan(figures.pointer) + ' ' : '  ';
+              }
               return `${prefix} ${title}`;
             })
             .join('\n')

--- a/readme.md
+++ b/readme.md
@@ -558,7 +558,7 @@ Use <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the l
     message: 'Pick a color',
     choices: [
         { title: 'Red', value: '#ff0000' },
-        { title: 'Green', value: '#00ff00' },
+        { title: 'Green', value: '#00ff00', disabled: true },
         { title: 'Blue', value: '#0000ff' }
     ],
     initial: 1
@@ -571,7 +571,7 @@ Use <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the l
 | message | `string` | Prompt message to display |
 | initial | `number` | Index of default value |
 | format | `function` | Receive user input. The returned value will be added to the response object |
-| choices | `Array` | Array of choices objects `[{ title, value }, ...]` |
+| choices | `Array` | Array of choices objects `[{ title, value, disabled }, ...]` |
 | onState | `function` | On state change callback. Function signature is an `object` with two propetires: `value` and `aborted` |
 
 
@@ -591,7 +591,7 @@ By default this prompt returns an `array` containing the **values** of the selec
     message: 'Pick colors',
     choices: [
         { title: 'Red', value: '#ff0000' },
-        { title: 'Green', value: '#00ff00' },
+        { title: 'Green', value: '#00ff00', disabled: true },
         { title: 'Blue', value: '#0000ff', selected: true }
     ],
     initial: 1,
@@ -605,7 +605,7 @@ By default this prompt returns an `array` containing the **values** of the selec
 | --- | --- | --- |
 | message | `string` | Prompt message to display |
 | format | `function` | Receive user input. The returned value will be added to the response object |
-| choices | `Array` | Array of choices objects `[{ title, value, [selected] }, ...]` |
+| choices | `Array` | Array of choices objects `[{ title, value, disabled, [selected] }, ...]` |
 | max | `number` | Max select |
 | hint | `string` | Hint to display user |
 | onState | `function` | On state change callback. Function signature is an `object` with two propetires: `value` and `aborted` |

--- a/readme.md
+++ b/readme.md
@@ -543,7 +543,7 @@ Use tab or <kbd>arrow keys</kbd>/<kbd>tab</kbd>/<kbd>space</kbd> to switch betwe
 | inactive | `string` | Text for `inactive` state. Defaults to `'off'` |
 | onState | `function` | On state change callback. Function signature is an `object` with two propetires: `value` and `aborted` |
 
-### select(message, choices, [initial])
+### select(message, choices, [initial], [warn])
 > Interactive select prompt.
 
 Use <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the list.
@@ -571,11 +571,12 @@ Use <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the l
 | message | `string` | Prompt message to display |
 | initial | `number` | Index of default value |
 | format | `function` | Receive user input. The returned value will be added to the response object |
+| warn | `string` | Message to display when selecting a disabled option |
 | choices | `Array` | Array of choices objects `[{ title, value, disabled }, ...]` |
 | onState | `function` | On state change callback. Function signature is an `object` with two propetires: `value` and `aborted` |
 
 
-### multiselect(message, choices, [initial], [max], [hint])
+### multiselect(message, choices, [initial], [max], [hint], [warn])
 > Interactive multi-select prompt.
 
 Use <kbd>space</kbd> to toggle select/unselect and <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the list. You can also use <kbd>right</kbd> to select and <kbd>left</kbd> to deselect.
@@ -608,6 +609,7 @@ By default this prompt returns an `array` containing the **values** of the selec
 | choices | `Array` | Array of choices objects `[{ title, value, disabled, [selected] }, ...]` |
 | max | `number` | Max select |
 | hint | `string` | Hint to display user |
+| warn | `string` | Message to display when selecting a disabled option |
 | onState | `function` | On state change callback. Function signature is an `object` with two propetires: `value` and `aborted` |
 
 This is one of the few prompts that don't take a initial value.


### PR DESCRIPTION
Adds a `disabled` option on choice objects for select and multiselect prompts.

Fix #96 