### PR TITLE
Update readme with `hint` option for `select` prompt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -581,7 +581,7 @@ Use tab or <kbd>arrow keys</kbd>/<kbd>tab</kbd>/<kbd>space</kbd> to switch betwe
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two propetires: `value` and `aborted` |
 
-### select(message, choices, [initial], [warn])
+### select(message, choices, [initial], [hint], [warn])
 > Interactive select prompt.
 
 Use <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the list.
@@ -609,6 +609,7 @@ Use <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the l
 | message | `string` | Prompt message to display |
 | initial | `number` | Index of default value |
 | format | `function` | Receive user input. The returned value will be added to the response object |
+| hint | `string` | Hint to display to the user |
 | warn | `string` | Message to display when selecting a disabled option |
 | choices | `Array` | Array of choices objects `[{ title, value, disabled }, ...]` |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
@@ -646,7 +647,7 @@ By default this prompt returns an `array` containing the **values** of the selec
 | format | `function` | Receive user input. The returned value will be added to the response object |
 | choices | `Array` | Array of choices objects `[{ title, value, disabled, [selected] }, ...]` |
 | max | `number` | Max select |
-| hint | `string` | Hint to display user |
+| hint | `string` | Hint to display to the user |
 | warn | `string` | Message to display when selecting a disabled option |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two propetires: `value` and `aborted` |


### PR DESCRIPTION
In using the `select` prompt, I had to do some digging around in the source code to find that it, like the `multiselect` prompt, accepts a `hint` option.

This PR adds that info to the readme and fixes a minor typo in the option description.

The associated gif seems to be out of date, as it doesn't display a hint. It looks like @terkelg has a preferred method of generating the gifs, though, so I didn't mess with it.