### PR TITLE
Bugfix/121 fallback not working on autocomplete

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -57,8 +57,7 @@ class AutocompletePrompt extends Prompt {
     this.select = i;
     if (this.suggestions.length > 0) {
       this.value = getVal(this.suggestions, i);
-    }
-    else {
+    } else {
       this.value = this.initial !== undefined
         ? getVal(this.choices, this.initial)
         : null;
@@ -211,7 +210,11 @@ class AutocompletePrompt extends Prompt {
       if (suggestions && !this.isFallback) {
         prompt += suggestions;
       } else {
-        prompt += `\n${color.gray(this.fallback)}`;
+        const fallbackIndex = getIndex(this.choices, this.fallback);
+        const fallbackTitle = fallbackIndex !== undefined
+          ? getTitle(this.choices, fallbackIndex)
+          : this.fallback;
+        prompt += `\n${color.gray(fallbackTitle)}`;
       }
     }
 

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -7,6 +7,10 @@ const { style, clear, figures, strip } = require('../util');
 
 const getVal = (arr, i) => arr[i] && (arr[i].value || arr[i].title || arr[i]);
 const getTitle = (arr, i) => arr[i] && (arr[i].title || arr[i].value || arr[i]);
+const getIndex = (arr, valOrTitle) => {
+  const index = arr.findIndex(el => el.value === valOrTitle || el.title === valOrTitle)
+  return index > -1 ? index : undefined;
+};
 
 /**
  * TextPrompt Base Element
@@ -29,8 +33,8 @@ class AutocompletePrompt extends Prompt {
     this.msg = opts.message;
     this.suggest = opts.suggest;
     this.choices = opts.choices;
-    this.initial = opts.initial;
-    this.select = opts.initial || opts.cursor || 0;
+    this.initial = getIndex(opts.choices, opts.initial);
+    this.select = this.initial || opts.cursor || 0;
     this.fallback = opts.fallback || (
       opts.initial !== undefined ?
         `${figures.pointerSmall} ${getTitle(this.choices, this.initial)}` :

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -33,7 +33,9 @@ class AutocompletePrompt extends Prompt {
     this.msg = opts.message;
     this.suggest = opts.suggest;
     this.choices = opts.choices;
-    this.initial = opts.initial !== undefined && getIndex(opts.choices, opts.initial);
+    this.initial = typeof opts.initial === 'number'
+      ? opts.initial
+      : getIndex(opts.choices, opts.initial);
     this.select = this.initial || opts.cursor || 0;
     this.fallback = opts.fallback || (
       opts.initial !== undefined ?

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -33,7 +33,7 @@ class AutocompletePrompt extends Prompt {
     this.msg = opts.message;
     this.suggest = opts.suggest;
     this.choices = opts.choices;
-    this.initial = getIndex(opts.choices, opts.initial);
+    this.initial = opts.initial !== undefined && getIndex(opts.choices, opts.initial);
     this.select = this.initial || opts.cursor || 0;
     this.fallback = opts.fallback || (
       opts.initial !== undefined ?
@@ -55,8 +55,14 @@ class AutocompletePrompt extends Prompt {
 
   moveSelect(i) {
     this.select = i;
-    if (this.suggestions.length > 0) this.value = getVal(this.suggestions, i);
-    else this.value = this.initial !== void 0 ? getVal(this.choices, this.initial) : null;
+    if (this.suggestions.length > 0) {
+      this.value = getVal(this.suggestions, i);
+    }
+    else {
+      this.value = this.initial !== undefined
+        ? getVal(this.choices, this.initial)
+        : null;
+    };
     this.fire();
   }
 
@@ -72,12 +78,14 @@ class AutocompletePrompt extends Prompt {
 
     if (!this.suggestions.length && this.fallback) {
       const index = getIndex(this.choices, this.fallback);
-      this.suggestions = [
-        {
-          title: getTitle(this.choices, index),
-          value: getVal(this.choices, index),
-        },
-      ];
+      this.suggestions = index !== undefined
+        ? [
+            {
+              title: getTitle(this.choices, index),
+              value: getVal(this.choices, index),
+            },
+          ]
+        : [];
       this.isFallback = true;
     }
 

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -8,7 +8,7 @@ const { style, clear, figures, strip } = require('../util');
 const getVal = (arr, i) => arr[i] && (arr[i].value || arr[i].title || arr[i]);
 const getTitle = (arr, i) => arr[i] && (arr[i].title || arr[i].value || arr[i]);
 const getIndex = (arr, valOrTitle) => {
-  const index = arr.findIndex(el => el.value === valOrTitle || el.title === valOrTitle)
+  const index = arr.findIndex(el => el.value === valOrTitle || el.title === valOrTitle);
   return index > -1 ? index : undefined;
 };
 

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -67,7 +67,19 @@ class AutocompletePrompt extends Prompt {
     if (this.completing !== p) return;
     this.suggestions = suggestions.slice(0, this.limit)
         .map((s, i, arr) => ({title: getTitle(arr, i), value: getVal(arr, i)}));
+    this.isFallback = false;
     this.completing = false;
+
+    if (!this.suggestions.length && this.fallback) {
+      const index = getIndex(this.choices, this.fallback);
+      this.suggestions = [
+        {
+          title: getTitle(this.choices, index),
+          value: getVal(this.choices, index),
+        },
+      ];
+      this.isFallback = true;
+    }
 
     const l = Math.max(suggestions.length - 1, 0);
     this.moveSelect(Math.min(l, this.select));
@@ -188,11 +200,10 @@ class AutocompletePrompt extends Prompt {
       this.lineCount = this.suggestions.length;
       let suggestions = this.suggestions.reduce((acc, item, i) =>
         acc + `\n${i === this.select ? color.cyan(item.title) : item.title}`, '');
-      if (suggestions) {
+      if (suggestions && !this.isFallback) {
         prompt += suggestions;
       } else {
         prompt += `\n${color.gray(this.fallback)}`;
-        this.lineCount += 1;
       }
     }
 

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -31,9 +31,11 @@ class AutocompletePrompt extends Prompt {
     this.choices = opts.choices;
     this.initial = opts.initial;
     this.select = opts.initial || opts.cursor || 0;
-    this.fallback = opts.fallback || opts.initial !== void 0 ?
-      `${figures.pointerSmall} ${getTitle(this.choices, this.initial)}` :
-      `${figures.pointerSmall} ${opts.noMatches || 'no matches found'}`;
+    this.fallback = opts.fallback || (
+      opts.initial !== undefined ?
+        `${figures.pointerSmall} ${getTitle(this.choices, this.initial)}` :
+        `${figures.pointerSmall} ${opts.noMatches || 'no matches found'}`
+    );
     this.suggestions = [];
     this.input = '';
     this.limit = opts.limit || 10;

--- a/readme.md
+++ b/readme.md
@@ -692,8 +692,8 @@ You can overwrite how choices are being filtered by passing your own suggest fun
 | suggest | `function` | Filter function. Defaults to sort by `title` property. `suggest` should always return a promise. Filters using `title` by default  |
 | limit | `number` | Max number of results to show. Defaults to `10` |
 | style | `string` | Render style (`default`, `password`, `invisible`, `emoji`). Defaults to `'default'` |
-| initial | Default initial value |
-| fallback | Fallback message when no match is found. Defaults to `initial` value if provided |
+| initial | `string | number` | Default initial value |
+| fallback | `function` | Fallback message when no match is found. Defaults to `initial` value if provided |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two propetires: `value` and `aborted` |
 


### PR DESCRIPTION
Fixes the fallback and initial values

This solution also checks the fallback value against the possible choices and uses its value if possible. Otherwise `undefined` is set for the questions value.