### PR TITLE
fix: fallback to transpiled code on Node.js version <8.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,14 @@
+function isNodeLT(tar) {
+  tar = (Array.isArray(tar) ? tar : tar.split('.')).map(Number);
+  let i=0, src=process.versions.node.split('.').map(Number);
+  for (; i < tar.length; i++) {
+    if (src[i] > tar[i]) return false;
+    if (tar[i] > src[i]) return true;
+  }
+  return false;
+}
+
 module.exports =
-  parseInt(process.versions.node, 10) < 8
+  isNodeLT('8.6.0')
     ? require('./dist/index.js')
     : require('./lib/index.js');


### PR DESCRIPTION
As mentioned in https://github.com/terkelg/prompts/issues/159#issuecomment-494185652, `prompts` crashes on Node versions between 8.0 and 8.6 because of usage of object spread operator (for example in https://github.com/terkelg/prompts/blob/91be062df45517046d53cdbede16992ff1d19ad0/lib/index.js#L35)

This change will serve transpiled code on Node versions that don't support object spread operator

fixes #159