### PR TITLE
feat(actions): moving with J and K on select mode

### DIFF
--- a/lib/elements/prompt.js
+++ b/lib/elements/prompt.js
@@ -19,14 +19,13 @@ class Prompt extends EventEmitter {
     this.in = opts.in || process.stdin;
     this.out = opts.out || process.stdout;
     this.onRender = (opts.onRender || (() => void 0)).bind(this);
-
     const rl = readline.createInterface(this.in);
     readline.emitKeypressEvents(this.in, rl);
 
     if (this.in.isTTY) this.in.setRawMode(true);
-
+    const isSelect = ['SelectPrompt', 'MultiselectPrompt'].indexOf(this.constructor.name) > -1;
     const keypress = (str, key) => {
-      let a = action(key);
+      let a = action(key, isSelect);
       if (a === false) {
         this._ && this._(str, key);
       } else if (typeof this[a] === 'function') {

--- a/lib/util/action.js
+++ b/lib/util/action.js
@@ -1,12 +1,17 @@
 'use strict';
 
-module.exports = key => {
+module.exports = (key, isSelect) => {
   if (key.ctrl) {
     if (key.name === 'a') return 'first';
     if (key.name === 'c') return 'abort';
     if (key.name === 'd') return 'abort';
     if (key.name === 'e') return 'last';
     if (key.name === 'g') return 'reset';
+  }
+  
+  if (isSelect) {
+    if (key.name === 'j') return 'down';
+    if (key.name === 'k') return 'up';
   }
 
   if (key.name === 'return') return 'submit';


### PR DESCRIPTION
Add `J` & `K` to move action, only work on `select` mode. (this is similar to `vim`, friendship and quickness.)
