### PR TITLE
press 'a' to toggle all in multiselect

### DIFF
--- a/lib/elements/multiselect.js
+++ b/lib/elements/multiselect.js
@@ -137,9 +137,21 @@ class MultiselectPrompt extends Prompt {
     }
   }
 
+  toggleAll() {
+    if (this.maxChoices !== undefined || this.value[this.cursor].disabled) {
+      return this.bell();
+    }
+
+    const newSelected = !this.value[this.cursor].selected;
+    this.value.filter(v => !v.disabled).forEach(v => v.selected = newSelected);
+    this.render();
+  }
+
   _(c, key) {
     if (c === ' ') {
       this.handleSpaceToggle();
+    } else if (c === 'a') {
+      this.toggleAll();
     } else {
       return this.bell();
     }
@@ -153,6 +165,7 @@ class MultiselectPrompt extends Prompt {
       return '\nInstructions:\n'
         + `    ${figures.arrowUp}/${figures.arrowDown}: Highlight option\n`
         + `    ${figures.arrowLeft}/${figures.arrowRight}/[space]: Toggle selection\n`
+        + (this.maxChoices === undefined ? `    a: Toggle all\n` : '')
         + `    enter/return: Complete answer`;
     }
     return '';


### PR DESCRIPTION
Resolves #162.
Tested manually because it appears there are no automatic tests for the multiselect prompt.
'a' is disabled (and not shown in instructions) if `maxChoices` are given, because there is no sensible strategy to toggle all if it would exceed the max, so it'd have to behave unintuitively otherwise.