### PR TITLE
docs: Match onSubmit signature from description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ Return `true` to quit the prompt chain and return all collected responses so far
 ```js
 (async () => {
   const questions = [{ ... }];
-  const onSubmit = (prompt, response) => console.log(`Thanks I got ${response} from ${prompt.name}`);
+  const onSubmit = (prompt, answer) => console.log(`Thanks I got ${answer} from ${prompt.name}`);
   const response = await prompts(questions, { onSubmit });
 })();
 ```


### PR DESCRIPTION
The [options.onSubmit](https://github.com/terkelg/prompts#optionsonsubmit) section writes that `answer` is the user's answer to the current question but then uses `response` in the following code example. I updated it so that the code example matches the description.