### PR TITLE
Fix for #208 opts.out changed to opts.stdout

### DIFF
--- a/lib/elements/prompt.js
+++ b/lib/elements/prompt.js
@@ -16,8 +16,8 @@ class Prompt extends EventEmitter {
     super();
 
     this.firstRender = true;
-    this.in = opts.in || process.stdin;
-    this.out = opts.out || process.stdout;
+    this.in = opts.stdin || process.stdin;
+    this.out = opts.stdout || process.stdout;
     this.onRender = (opts.onRender || (() => void 0)).bind(this);
     const rl = readline.createInterface(this.in);
     readline.emitKeypressEvents(this.in, rl);


### PR DESCRIPTION
This solves #208 .
In the repository `opts.stdout` is mentioned everywhere (in parameters and other comments) though passing stdout through the question object was not working since it was defined as variable `opts.out` in code.

I changed `opts.out` to `opts.stdout` so now passing standard output works by passing `stdout` key through question.