### PR TITLE
Hiding page number when only single page is there

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -243,7 +243,7 @@ class AutocompletePrompt extends Prompt {
         .map((item, i) => this.renderOption(item, this.select === i))
         .join('\n');
       this.outputText += `\n` + (suggestions || color.gray(this.fallback.title));
-      if (this.suggestions[this.page].length > 1 || this.suggestions.length > 1) {
+      if (this.suggestions[this.page].length > 1 && this.suggestions.length > 1) {
         this.outputText += color.blue(`\nPage ${this.page+1}/${this.suggestions.length}`);
       }
     }

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -243,8 +243,7 @@ class AutocompletePrompt extends Prompt {
         .map((item, i) => this.renderOption(item, this.select === i))
         .join('\n');
       this.outputText += `\n` + (suggestions || color.gray(this.fallback.title));
-
-      if (this.suggestions[this.page].length > 1) {
+      if (this.suggestions[this.page].length > 1 || this.suggestions.length > 1) {
         this.outputText += color.blue(`\nPage ${this.page+1}/${this.suggestions.length}`);
       }
     }


### PR DESCRIPTION
Issue is mentioned in #207 

So now when there's only one page. It does not show `Page [1/1]` 
![Screenshot from 2019-09-30 17-25-37](https://user-images.githubusercontent.com/30949385/65904730-aca02f00-e3dc-11e9-8650-8c5720c9b752.png)


But when there are multiple pages it will work the same as it does right now