### PR TITLE
Ability to programmatically cancel most recent prompt as per #213

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const prompts = require('./prompts');
+const { cancel } = require('./util');
 
 const passOn = ['suggest', 'format', 'onState', 'validate', 'onRender'];
 const noop = () => {};
@@ -89,4 +90,11 @@ function override(answers) {
   prompt._override = Object.assign({}, answers);
 }
 
-module.exports = Object.assign(prompt, { prompt, prompts, inject, override });
+/**
+ * Cancel the most recent prompt e.g. when it has been superseded
+ */
+function cancelMostRecent() {
+  cancel.cancelMostRecent();
+}
+
+module.exports = Object.assign(prompt, { prompt, prompts, inject, override, cancelMostRecent });

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,11 +1,13 @@
 'use strict';
 const $ = exports;
 const el = require('./elements');
+const { cancel } = require('./util');
 const noop = v => v;
 
 function toPrompt(type, args, opts={}) {
   return new Promise((res, rej) => {
     const p = new el[type](args);
+    cancel.storeActive(p);
     const onAbort = opts.onAbort || noop;
     const onSubmit = opts.onSubmit || noop;
     p.on('state', args.onState || noop);

--- a/lib/util/cancel.js
+++ b/lib/util/cancel.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// A place to store the most recent prompt
+let activePrompt;
+
+/**
+ * Records the most recently created prompt
+ */
+const storeActive = prompt => activePrompt = prompt;
+
+/**
+ * Cancels the most recently created active prompt
+ */
+const cancelMostRecent = () => {
+  if (activePrompt && !activePrompt.closed) {
+    activePrompt.abort();
+  }
+};
+
+module.exports = { storeActive, cancelMostRecent };

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -7,5 +7,6 @@ module.exports = {
   strip: require('./strip'),
   figures: require('./figures'),
   lines: require('./lines'),
-  wrap: require('./wrap')
+  wrap: require('./wrap'),
+  cancel: require('./cancel')
 };

--- a/readme.md
+++ b/readme.md
@@ -299,6 +299,35 @@ prompts.inject([ '@terkelg', ['#ff0000', '#0000ff'] ]);
 })();
 ```
 
+### cancelMostRecent
+
+Type: `Function`
+
+Programmatically cancel the most recent prompt. This can be useful if, say, the prompt has timed out or been superseded by a more important one.
+
+**Example:**
+```js
+const prompts = require('prompts');
+
+(async () => {
+  const response = await prompts([
+    {
+      type: 'select',
+      name: 'quiz',
+      message: `What's the capital of Canada?`,
+      choices: [
+        { title: 'Ottawa' },
+        { title: 'Vancouver' },
+        { title: 'Toronto' }
+      ],
+    }
+  ]);
+})();
+
+// Only 10 seconds to answer
+setTimeout(() => prompts.cancelMostRecent(), 10000);
+```
+
 ![split](https://github.com/terkelg/prompts/raw/master/media/split.png)
 
 

--- a/test/prompts.js
+++ b/test/prompts.js
@@ -56,3 +56,24 @@ test('injects', t => {
         });
     });
 });
+
+test('cancel', t => {
+  let onCancelCalled = false;
+  prompt([
+    {
+      type: 'select',
+      name: 'quiz',
+      message: `What's the capital of Canada?`,
+      choices: [
+        { title: 'Ottawa' },
+        { title: 'Vancouver' },
+        { title: 'Toronto' }
+      ],
+      onCancel: () => onCancelCalled = true
+    }
+  ]);
+
+  prompt.cancelMostRecent();
+  t.true(onCancelCalled, 'prompt is cancelled');
+  t.end();
+});


### PR DESCRIPTION
 * Adds functionality mentioned in #213
 * Useful if e.g. the user takes too long to respond or the prompt is superseded by a more important one
 * cancelMostRecent method added to API
 * Most recently created prompt can be programmatically cancelled
 * Test added
 * readme.md updated