### PR TITLE
Evaluate type before other options and skip if falsy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 const prompts = require('./prompts');
 
-const passOn = ['suggest', 'format', 'onState', 'validate', 'onRender'];
+const passOn = ['suggest', 'format', 'onState', 'validate', 'onRender', 'type'];
 const noop = () => {};
 
 /**
@@ -28,6 +28,13 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
   for (question of questions) {
     ({ name, type } = question);
 
+    // evaluate type first and skip if type is a falsy value
+    if (typeof type === 'function') {
+      type = await type(answer, { ...answers }, question)
+      question['type'] = type
+    }
+    if (!type) continue;
+
     // if property is a function, invoke it unless it's a special function
     for (let key in question) {
       if (passOn.includes(key)) continue;
@@ -41,9 +48,6 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
 
     // update vars in case they changed
     ({ name, type } = question);
-
-    // skip if type is a falsy value
-    if (!type) continue;
 
     if (prompts[type] === void 0) {
       throw new Error(`prompt type (${type}) is not defined`);


### PR DESCRIPTION
Evaluate the `type` option first so that if it evaluates to falsy we can skip the question earlier and not evaluate other options (e.g. `choices`, `message`).

This fixes #211.

I haven't written a test case as I wasn't sure how to fit it into the current structure.