### PR TITLE
Store correct reference of last prompt

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
   const answers = {};
   const override = prompt._override || {};
   questions = [].concat(questions);
-  let answer, question, quit, name, type;
+  let answer, question, quit, name, type, lastPrompt;
 
   const getFormattedAnswer = async (question, answer, skipValidation = false) => {
     if (!skipValidation && question.validate && question.validate(answer) !== true) {
@@ -39,8 +39,10 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
     for (let key in question) {
       if (passOn.includes(key)) continue;
       let value = question[key];
-      question[key] = typeof value === 'function' ? await value(answer, { ...answers }, question) : value;
+      question[key] = typeof value === 'function' ? await value(answer, { ...answers }, lastPrompt) : value;
     }
+
+    lastPrompt = question;
 
     if (typeof question.message !== 'string') {
       throw new Error('prompt message is required');


### PR DESCRIPTION
According to documentation:

> The function signature is (prev, values, prompt), where prev is the value from the previous prompt, values is the response object with all values collected so far and prompt is the previous prompt object.

So, whenever evaluating **prompt** for a dynamic question it was referring the current question instead.

Basically this PR stores `last question` and pass the correct reference to be evaluated.

This fixes #198