### PR TITLE
add a "smooth" option to autocomplete 

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -26,6 +26,7 @@ const getIndex = (arr, valOrTitle) => {
  * @param {Stream} [opts.stdin] The Readable stream to listen to
  * @param {Stream} [opts.stdout] The Writable stream to write readline data to
  * @param {String} [opts.noMatches] The no matches found label
+ * @param {Boolean} [opts.smooth] One single page, but use limit for display window size
  */
 class AutocompletePrompt extends Prompt {
   constructor(opts={}) {
@@ -42,7 +43,9 @@ class AutocompletePrompt extends Prompt {
     this.suggestions = [[]];
     this.page = 0;
     this.input = '';
-    this.limit = opts.limit || 10;
+    this.smooth = opts.smooth;
+    this.limit = this.smooth ? this.choices.length : opts.limit;
+    this.window = this.smooth && opts.limit;
     this.cursor = 0;
     this.transform = style.render(opts.style);
     this.scale = this.transform.scale;
@@ -224,26 +227,37 @@ class AutocompletePrompt extends Prompt {
     return title + color.gray(desc || '');
   }
 
+  visSublist(sugg) {
+    if (!this.smooth) {
+      return sugg;
+    }
+    this.winstart = Math.max(0, Math.min(this.select - Math.floor(this.window / 2), sugg.length - this.window));
+    this.winend = Math.min(sugg.length, this.winstart + this.window) - 1;
+    return sugg.slice(this.winstart, this.winend + 1);
+  }
+
   render() {
     if (this.closed) return;
     if (!this.firstRender) this.out.write(clear(this.outputText));
     super.render();
 
+    let vislist = this.visSublist(this.suggestions[this.page]);
+    let select = this.smooth ? this.select - this.winstart : this.select;
     this.outputText = [
       color.bold(style.symbol(this.done, this.aborted)),
       color.bold(this.msg),
       style.delimiter(this.completing),
-      this.done && this.suggestions[this.page][this.select]
-          ? this.suggestions[this.page][this.select].title
+      this.done && vislist[select]
+          ? vislist[select].title
           : this.rendered = this.transform.render(this.input)
     ].join(' ');
 
     if (!this.done) {
-      const suggestions = this.suggestions[this.page]
-        .map((item, i) => this.renderOption(item, this.select === i))
+      const suggestions = vislist
+        .map((item, i) => this.renderOption(item, (select) === i))
         .join('\n');
       this.outputText += `\n` + (suggestions || color.gray(this.fallback.title));
-      if (this.suggestions[this.page].length > 1 && this.suggestions.length > 1) {
+      if (vislist.length > 1 && this.suggestions.length > 1) {
         this.outputText += color.blue(`\nPage ${this.page+1}/${this.suggestions.length}`);
       }
     }


### PR DESCRIPTION
that will cause there to be just one single page but only display a window of that info. To address: [this issue](https://github.com/terkelg/prompts/issues/163)

If you add parameter:
`smooth: true`
the `limit` value will be used for the visible window of choices, but there will be no pages, only a sliding window as user scrolls through items.
I don't know if I'm following your code vibe, so feel free to do this in a more integrated way if this doesn't work.