### PR TITLE
Text prompt hint

### DIFF
--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -184,6 +184,7 @@ class TextPrompt extends Prompt {
     if (this.error || this.hint) {
       this.postMessage = (this.error ? this.errorMsg : this.hint).split(`\n`)
         .reduce((a, l, i) => a + `\n${i ? ' ' : figures.pointerSmall} ${this.error ? color.red().italic(l) : color.gray().italic(l)}`, ``)
+      if (this.hint) this.error = false;
     }
 
     this.out.write(cursor.to(0) + this.outputText + erase.lineEnd + this.postMessage + cursor.up(lines(this.postMessage - 1)) + cursor.to(outputLength));

--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -186,7 +186,7 @@ class TextPrompt extends Prompt {
         .reduce((a, l, i) => a + `\n${i ? ' ' : figures.pointerSmall} ${this.error ? color.red().italic(l) : color.gray().italic(l)}`, ``)
     }
 
-    this.out.write(erase.line + cursor.to(0) + this.outputText + cursor.save + this.outputError + cursor.restore);
+    this.out.write(cursor.to(0) + this.outputText + erase.lineEnd + this.postMessage + cursor.up(lines(this.postMessage - 1)) + cursor.to(outputLength));
   }
 }
 

--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -21,6 +21,7 @@ class TextPrompt extends Prompt {
     this.scale = this.transform.scale;
     this.msg = opts.message;
     this.initial = opts.initial || ``;
+    this.hint = opts.hint || ``;
     this.validator = opts.validate || (() => true);
     this.value = ``;
     this.errorMsg = opts.error || `Please Enter A Valid Value`;
@@ -155,12 +156,12 @@ class TextPrompt extends Prompt {
   render() {
     if (this.closed) return;
     if (!this.firstRender) {
-      if (this.outputError)
-        this.out.write(cursor.down(lines(this.outputError) - 1) + clear(this.outputError));
+      if (this.postMessage)
+        this.out.write(cursor.down(lines(this.postMessage) - 1) + clear(this.postMessage));
       this.out.write(clear(this.outputText));
     }
     super.render();
-    this.outputError = '';
+    this.postMessage = ``;
 
     this.outputText = [
       style.symbol(this.done, this.aborted),
@@ -169,9 +170,20 @@ class TextPrompt extends Prompt {
       this.red ? color.red(this.rendered) : this.rendered
     ].join(` `);
 
-    if (this.error) {
-      this.outputError += this.errorMsg.split(`\n`)
-          .reduce((a, l, i) => a + `\n${i ? ' ' : figures.pointerSmall} ${color.red().italic(l)}`, ``);
+    const outputLength = (
+      /* symbol length */
+      2 +
+      /* prompt */
+      this.msg.length +
+      /* delimiter */
+      3 +
+      /* input */
+      this.value.length
+    )
+
+    if (this.error || this.hint) {
+      this.postMessage = (this.error ? this.errorMsg : this.hint).split(`\n`)
+        .reduce((a, l, i) => a + `\n${i ? ' ' : figures.pointerSmall} ${this.error ? color.red().italic(l) : color.gray().italic(l)}`, ``)
     }
 
     this.out.write(erase.line + cursor.to(0) + this.outputText + cursor.save + this.outputError + cursor.restore);


### PR DESCRIPTION
This PR adds the feature to display a hint to the user when giving them a `text` type prompt.

It will display the hint below the prompt, so some of the logic surrounding displaying errors had to be changed to support displaying a hint as well.

Additionally, `cursor.restore` is not supported on some terminals, so I changed the logic some to support displaying a message below the prompt, then resetting the cursor where it needs to go.  This method reduces some of the flicker, too (it was really bad in some terminals), because it is not erasing all of the text then redrawing it every time.  There is still some flicker, and it could probably be fine tuned some more, but I wasn't interested in going deeper than that.

The way it is now makes more sense, too, if you include an `initial` value.  Your cursor will be at the beginning of the initial value, instead of at the end, so it is apparent that you are going to type over the default.