### PR TITLE
Remove multi-pages on autocomplete, instead scroll down/up

### DIFF
--- a/example.js
+++ b/example.js
@@ -75,6 +75,7 @@ let interval;
             message: 'Pick your favorite actor',
             initial: 1,
             limit: 3,
+            suggest: (input, choices) => choices.filter(i => i.title.toLowerCase().includes(input.toLowerCase())),
             choices: [
                 { title: 'Cage' },
                 { title: 'Clooney', value: 'silver-fox' },

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -3,7 +3,7 @@
 const color = require('kleur');
 const Prompt = require('./prompt');
 const { erase, cursor } = require('sisteransi');
-const { style, clear, wrap } = require('../util');
+const { style, clear, figures, wrap, entriesToDisplay } = require('../util');
 
 const getVal = (arr, i) => arr[i] && (arr[i].value || arr[i].title || arr[i]);
 const getTitle = (arr, i) => arr[i] && (arr[i].title || arr[i].value || arr[i]);
@@ -39,8 +39,7 @@ class AutocompletePrompt extends Prompt {
     this.select = this.initial || opts.cursor || 0;
     this.i18n = { noMatches: opts.noMatches || 'no matches found' };
     this.fallback = opts.fallback || this.initial;
-    this.suggestions = [[]];
-    this.page = 0;
+    this.suggestions = [];
     this.input = '';
     this.limit = opts.limit || 10;
     this.cursor = 0;
@@ -68,8 +67,8 @@ class AutocompletePrompt extends Prompt {
 
   moveSelect(i) {
     this.select = i;
-    if (this.suggestions[this.page].length > 0)
-      this.value = getVal(this.suggestions[this.page], i);
+    if (this.suggestions.length > 0)
+      this.value = getVal(this.suggestions, i);
     else this.value = this.fallback.value;
     this.fire();
   }
@@ -80,15 +79,9 @@ class AutocompletePrompt extends Prompt {
 
     if (this.completing !== p) return;
     this.suggestions = suggestions
-        .map((s, i, arr) => ({ title: getTitle(arr, i), value: getVal(arr, i), description: s.description }))
-        .reduce((arr, sug) => {
-          if (arr[arr.length - 1].length < this.limit)
-            arr[arr.length - 1].push(sug);
-          else arr.push([sug]);
-          return arr;
-        }, [[]]);
+      .map((s, i, arr) => ({ title: getTitle(arr, i), value: getVal(arr, i), description: s.description }));
     this.completing = false;
-    if (!this.suggestions[this.page])
+    if (!this.suggestions)
       this.page = 0;
 
     const l = Math.max(suggestions.length - 1, 0);
@@ -143,12 +136,12 @@ class AutocompletePrompt extends Prompt {
   }
 
   deleteForward() {
-      if(this.cursor*this.scale >= this.rendered.length) return this.bell();
-      let s1 = this.input.slice(0, this.cursor);
-      let s2 = this.input.slice(this.cursor+1);
-      this.input = `${s1}${s2}`;
-      this.complete(this.render);
-      this.render();
+    if(this.cursor*this.scale >= this.rendered.length) return this.bell();
+    let s1 = this.input.slice(0, this.cursor);
+    let s2 = this.input.slice(this.cursor+1);
+    this.input = `${s1}${s2}`;
+    this.complete(this.render);
+    this.render();
   }
 
   first() {
@@ -157,7 +150,7 @@ class AutocompletePrompt extends Prompt {
   }
 
   last() {
-    this.moveSelect(this.suggestions[this.page].length - 1);
+    this.moveSelect(this.suggestions.length - 1);
     this.render();
   }
 
@@ -168,32 +161,25 @@ class AutocompletePrompt extends Prompt {
   }
 
   down() {
-    if (this.select >= this.suggestions[this.page].length - 1) return this.bell();
+    if (this.select >= this.suggestions.length - 1) return this.bell();
     this.moveSelect(this.select + 1);
     this.render();
   }
 
   next() {
-    if (this.select === this.suggestions[this.page].length - 1) {
-      this.page = (this.page + 1) % this.suggestions.length;
+    if (this.select === this.suggestions.length - 1) {
       this.moveSelect(0);
     } else this.moveSelect(this.select + 1);
     this.render();
   }
 
   nextPage() {
-    if (this.page >= this.suggestions.length - 1)
-      return this.bell();
-    this.page++;
-    this.moveSelect(0);
+    this.moveSelect(Math.min(this.select + this.limit, this.suggestions.length - 1));
     this.render();
   }
 
   prevPage() {
-    if (this.page <= 0)
-      return this.bell();
-    this.page--;
-    this.moveSelect(0);
+    this.moveSelect(Math.max(this.select - this.limit, 0));
     this.render();
   }
 
@@ -209,19 +195,19 @@ class AutocompletePrompt extends Prompt {
     this.render();
   }
 
-  renderOption(v, hovered) {
-    let desc, title = v.title;
-    if (hovered) {
-      title = color.cyan(v.title);
-      if (v.description) {
-        desc = ` - ${v.description}`;
-        if (title.length + desc.length >= this.out.columns
-          || v.description.split(/\r?\n/).length > 1) {
-          desc = '\n' + wrap(v.description, { width: this.out.columns })
-        }
+  renderOption(v, hovered, isStart, isEnd) {
+    let desc;
+    let prefix = isStart ? figures.arrowUp : isEnd ? figures.arrowDown : ' ';
+    let title = hovered ? color.cyan().underline(v.title) : v.title;
+    prefix = (hovered ? color.cyan(figures.pointer) + ' ' : '  ') + prefix;
+    if (v.description) {
+      desc = ` - ${v.description}`;
+      if (prefix.length + title.length + desc.length >= this.out.columns
+        || v.description.split(/\r?\n/).length > 1) {
+        desc = '\n' + wrap(v.description, { margin: 3, width: this.out.columns })
       }
     }
-    return title + color.gray(desc || '');
+    return prefix + ' ' + title + color.gray(desc || '');
   }
 
   render() {
@@ -229,23 +215,26 @@ class AutocompletePrompt extends Prompt {
     if (!this.firstRender) this.out.write(clear(this.outputText));
     super.render();
 
+    let { startIndex, endIndex } = entriesToDisplay(this.select, this.choices.length, this.limit);
+
     this.outputText = [
       color.bold(style.symbol(this.done, this.aborted)),
       color.bold(this.msg),
       style.delimiter(this.completing),
-      this.done && this.suggestions[this.page][this.select]
-          ? this.suggestions[this.page][this.select].title
-          : this.rendered = this.transform.render(this.input)
+      this.done && this.suggestions[this.select]
+        ? this.suggestions[this.select].title
+        : this.rendered = this.transform.render(this.input)
     ].join(' ');
 
     if (!this.done) {
-      const suggestions = this.suggestions[this.page]
-        .map((item, i) => this.renderOption(item, this.select === i))
+      const suggestions = this.suggestions
+        .slice(startIndex, endIndex)
+        .map((item, i) =>  this.renderOption(item,
+          this.select === i + startIndex,
+          i === 0 && startIndex > 0,
+          i + startIndex === endIndex - 1 && endIndex < this.choices.length))
         .join('\n');
       this.outputText += `\n` + (suggestions || color.gray(this.fallback.title));
-      if (this.suggestions[this.page].length > 1 && this.suggestions.length > 1) {
-        this.outputText += color.blue(`\nPage ${this.page+1}/${this.suggestions.length}`);
-      }
     }
 
     this.out.write(erase.line + cursor.to(0) + this.outputText);

--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -81,9 +81,6 @@ class AutocompletePrompt extends Prompt {
     this.suggestions = suggestions
       .map((s, i, arr) => ({ title: getTitle(arr, i), value: getVal(arr, i), description: s.description }));
     this.completing = false;
-    if (!this.suggestions)
-      this.page = 0;
-
     const l = Math.max(suggestions.length - 1, 0);
     this.moveSelect(Math.min(l, this.select));
 
@@ -116,7 +113,7 @@ class AutocompletePrompt extends Prompt {
     this.close();
   }
 
-  _(c, key) { // TODO on ctrl+# go to page #
+  _(c, key) {
     let s1 = this.input.slice(0, this.cursor);
     let s2 = this.input.slice(this.cursor);
     this.input = `${s1}${c}${s2}`;
@@ -212,7 +209,8 @@ class AutocompletePrompt extends Prompt {
 
   render() {
     if (this.closed) return;
-    if (!this.firstRender) this.out.write(clear(this.outputText));
+    if (this.firstRender) this.out.write(cursor.hide);
+    else this.out.write(clear(this.outputText));
     super.render();
 
     let { startIndex, endIndex } = entriesToDisplay(this.select, this.choices.length, this.limit);


### PR DESCRIPTION
Simplify and clean up `autocomplete` to be more like the new and improved `select`.
This removes pages entirely and instead smoothy allows scrolling through the options.