### PR TITLE
new prompts type allowing for subquestions 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
 
     lastPrompt = question;
 
-    if (typeof question.message !== 'string') {
+    if (typeof question.message !== 'string' && type !== 'prompts') {
       throw new Error('prompt message is required');
     }
 
@@ -65,7 +65,7 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
 
     try {
       // Get the injected answer if there is one or prompt the user
-      answer = prompt._injected ? getInjectedAnswer(prompt._injected) : await prompts[type](question);
+      answer = prompt._injected ? getInjectedAnswer(prompt._injected) : await prompts[type](question, prompt);
       answers[name] = answer = await getFormattedAnswer(question, answer, true);
       quit = await onSubmit(question, answer, answers);
     } catch (err) {

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -201,3 +201,15 @@ $.autocomplete = args => {
   args.choices = [].concat(args.choices || []);
   return toPrompt('AutocompletePrompt', args);
 };
+
+/**
+ * Dynamic creation of subquestions
+ * @param {Array} args.message Array of questions to prompt for
+ * @param {function} prompt The prompt function used to get answers for these questions
+ * @return {Promise} promise with object containing answers to these questions
+ */
+
+$.prompts = async (args, prompt) => {
+  const value = await prompt(args.message);
+  return value;
+};

--- a/test/prompts.js
+++ b/test/prompts.js
@@ -13,7 +13,7 @@ test('basics', t => {
 });
 
 test('prompts', t => {
-  t.plan(25);
+  t.plan(27);
 
   const types = [
     'text',
@@ -27,7 +27,8 @@ test('prompts', t => {
     'multiselect',
     'autocompleteMultiselect',
     'autocomplete',
-    'date'
+    'date',
+    'prompts',
   ];
 
   types.forEach(p => {


### PR DESCRIPTION
allows for new 'prompts' type that will process the message as a new set of questions to ask.
allows for dynamically adding questions to the set base on previous responses.

```javascript
const prompts = require('prompts');

const questions = [
    {
        type: 'number',
        name: 'players',
        message: 'Number of players?',
    },
    {
        type: 'prompts',
        name: 'ages',
        message: prev => {
            const empty = new Array(prev).fill({});
            const questions = empty.map((x, i) => ({
                type: 'number',
                name: `player${i+1}Age`,
                message: `Player ${i+1}'s Age?'`,
            }))
           return questions;
        }
    },
    {
        type: 'text',
        name: 'name',
        message: 'Name of game',
    }
];

(async () => {
    const config = await prompts(questions);
    console.log(config)
})();
```

Output: 
```
✔ Number of players? … 2
✔ Player 1's Age?' … 23
✔ Player 2's Age?' … 56
✔ Name of game … Testing
{ players: 2,
  ages: { player1Age: 23, player2Age: 56 },
  name: 'Testing' }
```