### PR TITLE
fix #245: home prints `undefined`

### DIFF
--- a/lib/util/action.js
+++ b/lib/util/action.js
@@ -25,6 +25,10 @@ module.exports = (key, isSelect) => {
   if (key.name === 'tab') return 'next';
   if (key.name === 'pagedown') return 'nextPage';
   if (key.name === 'pageup') return 'prevPage';
+  // TODO create home() in prompt types (e.g. TextPrompt)
+  if (key.name === 'home') return 'home';
+  // TODO create end() in prompt types (e.g. TextPrompt)
+  if (key.name === 'end') return 'end';
 
   if (key.name === 'up') return 'up';
   if (key.name === 'down') return 'down';


### PR DESCRIPTION
Simple fix to prevent <kbd>home</kbd> and <kbd>end</kbd> keys to print undefined. 