### PR TITLE
autocomplete: fix bold symbols

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -216,7 +216,7 @@ class AutocompletePrompt extends Prompt {
     let { startIndex, endIndex } = entriesToDisplay(this.select, this.choices.length, this.limit);
 
     this.outputText = [
-      color.bold(style.symbol(this.done, this.aborted)),
+      style.symbol(this.done, this.aborted),
       color.bold(this.msg),
       style.delimiter(this.completing),
       this.done && this.suggestions[this.select]


### PR DESCRIPTION
All the other prompts have regular weight symbols, this one sticked out:

<img width="278" alt="Screenshot 2020-03-02 at 13 23 24" src="https://user-images.githubusercontent.com/10247/75676172-03aa7880-5c89-11ea-9405-9c9042327f0d.png">
