### PR TITLE
Loop cursor on all select-style prompts

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -152,14 +152,20 @@ class AutocompletePrompt extends Prompt {
   }
 
   up() {
-    if (this.select <= 0) return this.bell();
-    this.moveSelect(this.select - 1);
+    if (this.select === 0) {
+      this.moveSelect(this.suggestions.length - 1);
+    } else {
+      this.moveSelect(this.select - 1);
+    }
     this.render();
   }
 
   down() {
-    if (this.select >= this.suggestions.length - 1) return this.bell();
-    this.moveSelect(this.select + 1);
+    if (this.select === this.suggestions.length - 1) {
+      this.moveSelect(0);
+    } else {
+      this.moveSelect(this.select + 1);
+    }
     this.render();
   }
 

--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -83,14 +83,20 @@ class SelectPrompt extends Prompt {
   }
 
   up() {
-    if (this.cursor === 0) return this.bell();
-    this.moveCursor(this.cursor - 1);
+    if (this.cursor === 0) {
+      this.moveCursor(this.choices.length - 1);
+    } else {
+      this.moveCursor(this.cursor - 1);
+    }
     this.render();
   }
 
   down() {
-    if (this.cursor === this.choices.length - 1) return this.bell();
-    this.moveCursor(this.cursor + 1);
+    if (this.cursor === this.choices.length - 1) {
+      this.moveCursor(0);
+    } else {
+      this.moveCursor(this.cursor + 1);
+    }
     this.render();
   }
 


### PR DESCRIPTION
Loops the cursor around to the top/bottom when arrowing at edges of a select list.
This already happens for `multiselect` & `autocompleteMultiselect`.  
This PR makes `select` & `autocomplete` behave the same way.

Closes https://github.com/terkelg/prompts/issues/269