### PR TITLE
use default value for number type prompts before triggering the validation

### DIFF
--- a/lib/elements/number.js
+++ b/lib/elements/number.js
@@ -99,6 +99,8 @@ class NumberPrompt extends Prompt {
   }
 
   async submit() {
+    const x = this.value;
+    this.value = x !== `` ? x : this.initial;
     await this.validate();
     if (this.error) {
       this.color = `red`;
@@ -106,8 +108,6 @@ class NumberPrompt extends Prompt {
       this.render();
       return;
     }
-    let x = this.value;
-    this.value = x !== `` ? x : this.initial;
     this.done = true;
     this.aborted = false;
     this.error = false;


### PR DESCRIPTION
Currently when the validation method is triggered if no value is provided and a default value is present for the question, it is not applied before triggering the validation. As a result the validation will fail, although the default is probably valid. This PR inverts the order of triggering validation and applying the default value (as it it already done for text prompts)