### PR TITLE
Added compressed size action

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,18 @@
+name: "Size"
+
+on:
+  pull_request:
+    types: [synchronize, opened]
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: preactjs/compressed-size-action@v2
+        continue-on-error: true
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          pattern: "**/lib/*.js"


### PR DESCRIPTION
# Why

I've switched create-react-app (react-dev-utils), create-react-native-app, and expo-cli over to it because of the immense size decrease from inquirer. 

In OSS, it can be easy to accidentally merge a lofty size increases, so to combat this, on `create-react-native-app` I've implemented the proposed action. [Demo comment](https://github.com/expo/create-react-native-app/pull/809#issuecomment-629576290).

This might not be a perfect fit for prompts since it doesn't use ncc (packaging all the libraries together), but it could still be pretty useful for code review.
