### PR TITLE
create asyncAutocomplete prompt that fetches choices dynamically

### DIFF
--- a/lib/elements/asyncAutocomplete.js
+++ b/lib/elements/asyncAutocomplete.js
@@ -1,0 +1,258 @@
+'use strict';
+
+const color = require('kleur');
+const Prompt = require('./prompt');
+const { erase, cursor } = require('sisteransi');
+const { style, clear, figures, wrap, entriesToDisplay } = require('../util');
+const CancelationToken = require('../util/cancelationToken')
+
+const getVal = (arr, i) => arr[i] && (arr[i].value || arr[i].title || arr[i]);
+const getTitle = (arr, i) => arr[i] && (arr[i].title || arr[i].value || arr[i]);
+const getIndex = (arr, valOrTitle) => {
+  const index = arr.findIndex(el => el.value === valOrTitle || el.title === valOrTitle);
+  return index > -1 ? index : undefined;
+};
+
+/**
+ * AsyncAutocompletePrompt Element
+ * @param {Object} opts Options
+ * @param {String} opts.message Message
+ * @param {Function} opts.suggest Gets choices based on user input
+ * @param {Number} [opts.limit=10] Max number of results to show
+ * @param {String} [opts.style='default'] Render style
+ * @param {Boolean} [opts.clearFirst] The first ESCAPE keypress will clear the input
+ * @param {Stream} [opts.stdin] The Readable stream to listen to
+ * @param {Stream} [opts.stdout] The Writable stream to write readline data to
+ * @param {String} [opts.noMatches] The no matches found label
+ */
+class AsyncAutocompletePrompt extends Prompt {
+  constructor(opts={}) {
+    super(opts);
+    this.msg = opts.message;
+    this.suggest = opts.suggest;
+    this.suggestions = []; 
+    this.select = 0;
+    this.i18n = { noMatches: opts.noMatches || 'no matches found' };
+    this.clearFirst = opts.clearFirst || false;
+    this.input = '';
+    this.limit = opts.limit || 10;
+    this.cursor = 0;
+    this.transform = style.render(opts.style);
+    this.scale = this.transform.scale;
+    this.render = this.render.bind(this);
+    this.complete = this.complete.bind(this);
+    this.clear = clear('', this.out.columns);
+    this.complete(this.render);
+    this.render();
+  }
+
+  moveSelect(i) {
+    this.select = i;
+    if (this.suggestions.length > 0)
+      this.value = getVal(this.suggestions, i);
+    else this.value = undefined;
+    this.fire();
+  }
+
+  async complete(cb) {
+    if (this.cancelationToken) this.cancelationToken.cancel();
+    try {
+      await this.completing
+    } catch (err) {
+      // ignore
+    }
+    const cancelationToken = this.cancelationToken = new CancelationToken();
+    const p = (this.completing = this.suggest(this.input, cancelationToken));
+    let suggestions
+    try {
+      suggestions = await p;
+    } catch (err) {
+      if (!cancelationToken.canceled) throw err;
+    }
+    if (cancelationToken.canceled) return;
+
+    if (this.completing !== p) return;
+    this.suggestions = suggestions
+      .map((s, i, arr) => ({ title: s.title, value: s.value, description: s.description }));
+    this.completing = false;
+    const initialIndex = suggestions.findIndex(s => s.initial);
+    if (initialIndex >= 0) {
+      this.moveSelect(initialIndex);
+    } else {
+      const l = Math.max(suggestions.length - 1, 0);
+      this.moveSelect(Math.min(l, this.select));
+    }
+
+    cb && cb();
+  }
+
+  reset() {
+    this.input = '';
+    this.complete(this.render);
+    this.render();
+  }
+
+  exit() {
+    if (this.clearFirst && this.input.length > 0) {
+      this.reset();
+    } else {
+      this.done = this.exited = true; 
+      this.aborted = false;
+      this.fire();
+      this.render();
+      this.out.write('\n');
+      this.close();
+    }
+  }
+
+  abort() {
+    this.done = this.aborted = true;
+    this.exited = false;
+    this.fire();
+    this.render();
+    this.out.write('\n');
+    this.close();
+  }
+
+  submit() {
+    this.done = true;
+    this.aborted = this.exited = false;
+    this.fire();
+    this.render();
+    this.out.write('\n');
+    this.close();
+  }
+
+  _(c, key) {
+    let s1 = this.input.slice(0, this.cursor);
+    let s2 = this.input.slice(this.cursor);
+    this.input = `${s1}${c}${s2}`;
+    this.cursor = s1.length+1;
+    this.complete(this.render);
+    this.render();
+  }
+
+  delete() {
+    if (this.cursor === 0) return this.bell();
+    let s1 = this.input.slice(0, this.cursor-1);
+    let s2 = this.input.slice(this.cursor);
+    this.input = `${s1}${s2}`;
+    this.complete(this.render);
+    this.cursor = this.cursor-1;
+    this.render();
+  }
+
+  deleteForward() {
+    if(this.cursor*this.scale >= this.rendered.length) return this.bell();
+    let s1 = this.input.slice(0, this.cursor);
+    let s2 = this.input.slice(this.cursor+1);
+    this.input = `${s1}${s2}`;
+    this.complete(this.render);
+    this.render();
+  }
+
+  first() {
+    this.moveSelect(0);
+    this.render();
+  }
+
+  last() {
+    this.moveSelect(this.suggestions.length - 1);
+    this.render();
+  }
+
+  up() {
+    if (this.select === 0) {
+      this.moveSelect(this.suggestions.length - 1);
+    } else {
+      this.moveSelect(this.select - 1);
+    }
+    this.render();
+  }
+
+  down() {
+    if (this.select === this.suggestions.length - 1) {
+      this.moveSelect(0);
+    } else {
+      this.moveSelect(this.select + 1);
+    }
+    this.render();
+  }
+
+  next() {
+    if (this.select === this.suggestions.length - 1) {
+      this.moveSelect(0);
+    } else this.moveSelect(this.select + 1);
+    this.render();
+  }
+
+  nextPage() {
+    this.moveSelect(Math.min(this.select + this.limit, this.suggestions.length - 1));
+    this.render();
+  }
+
+  prevPage() {
+    this.moveSelect(Math.max(this.select - this.limit, 0));
+    this.render();
+  }
+
+  left() {
+    if (this.cursor <= 0) return this.bell();
+    this.cursor = this.cursor-1;
+    this.render();
+  }
+
+  right() {
+    if (this.cursor*this.scale >= this.rendered.length) return this.bell();
+    this.cursor = this.cursor+1;
+    this.render();
+  }
+
+  renderOption(v, hovered, isStart, isEnd) {
+    let desc;
+    let prefix = isStart ? figures.arrowUp : isEnd ? figures.arrowDown : ' ';
+    let title = hovered ? color.cyan().underline(v.title) : v.title;
+    prefix = (hovered ? color.cyan(figures.pointer) + ' ' : '  ') + prefix;
+    if (v.description) {
+      desc = ` - ${v.description}`;
+      if (prefix.length + title.length + desc.length >= this.out.columns
+        || v.description.split(/\r?\n/).length > 1) {
+        desc = '\n' + wrap(v.description, { margin: 3, width: this.out.columns })
+      }
+    }
+    return prefix + ' ' + title + color.gray(desc || '');
+  }
+
+  render() {
+    if (this.closed) return;
+    if (this.firstRender) this.out.write(cursor.hide);
+    else this.out.write(clear(this.outputText, this.out.columns));
+    super.render();
+
+    let { startIndex, endIndex } = entriesToDisplay(this.select, this.suggestions.length, this.limit);
+
+    this.outputText = [
+      style.symbol(this.done, this.aborted, this.exited),
+      color.bold(this.msg),
+      style.delimiter(this.completing),
+      this.done && this.suggestions[this.select]
+        ? this.suggestions[this.select].title
+        : this.rendered = this.transform.render(this.input)
+    ].join(' ');
+
+    if (!this.done) {
+      const suggestions = this.suggestions
+        .slice(startIndex, endIndex)
+        .map((item, i) =>  this.renderOption(item,
+          this.select === i + startIndex,
+          i === 0 && startIndex > 0,
+          i + startIndex === endIndex - 1 && endIndex < this.suggestions.length))
+        .join('\n');
+      this.outputText += `\n` + suggestions;
+    }
+
+    this.out.write(erase.line + cursor.to(0) + this.outputText);
+  }
+}
+
+module.exports = AsyncAutocompletePrompt;

--- a/lib/elements/index.js
+++ b/lib/elements/index.js
@@ -8,6 +8,7 @@ module.exports = {
   NumberPrompt: require('./number'),
   MultiselectPrompt: require('./multiselect'),
   AutocompletePrompt: require('./autocomplete'),
+  AsyncAutocompletePrompt: require('./asyncAutocomplete'),
   AutocompleteMultiselectPrompt: require('./autocompleteMultiselect'),
   ConfirmPrompt: require('./confirm')
 };

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -204,3 +204,19 @@ $.autocomplete = args => {
   args.choices = [].concat(args.choices || []);
   return toPrompt('AutocompletePrompt', args);
 };
+
+/**
+ * Interactive auto-complete prompt that fetches choices asynchronously
+ * @param {string} args.message Prompt message to display
+ * @param {Function} args.suggest Function to suggest results based on user input.
+ * @param {number} [args.limit=10] Max number of results to show
+ * @param {string} [args.style="default"] Render style ('default', 'password', 'invisible')
+ * @param {boolean} [opts.clearFirst] The first ESCAPE keypress will clear the input
+ * @param {function} [args.onState] On state change callback
+ * @param {Stream} [args.stdin] The Readable stream to listen to
+ * @param {Stream} [args.stdout] The Writable stream to write readline data to
+ * @returns {Promise} Promise with user input
+ */
+$.asyncAutocomplete = args => {
+  return toPrompt('AsyncAutocompletePrompt', args);
+};

--- a/lib/util/cancelationToken.js
+++ b/lib/util/cancelationToken.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+class CancelationToken extends EventEmitter {
+  constructor() {
+    super();
+    this._canceled = false;
+  }
+
+  get canceled() {
+    return this._canceled;
+  }
+
+  cancel() {
+    if (!this._canceled) {
+      this._canceled = true;
+      this.emit('canceled');
+    }
+  }
+}
+
+module.exports = CancelationToken;


### PR DESCRIPTION
I've been wanting a CLI for quickly selecting an AWS EC2 instance etc, where the choices are fetched asynchronously instead of being a static list.  I was able to hack one together by forking `AutocompletePrompt`.  (See the real-world example of fetching EC2 instances based on the user input in my additions to the README.)

I wouldn't exactly call this PR complete, and I'm probably just going to release a scoped package with this fork, but if you like this idea I can work on it some more.

How it differs from `autocomplete` prompt:

* No `choices`, `initial`, or `fallback` options.
  * No choices appear until first call to `suggest` resolves
  * Any time the suggested choices change, the selection is reset to the first choice with `initial: true`, if one exists.
  * `suggest` can return a fallback choice if none was found.  This makes it possible for the fallback message to be dynamically generated.
* `suggest` is passed `input` and `cancelationToken`
  * `cancelationToken` has a `canceled` property and emits a `canceled` event when the user input has changed
  * `asyncAutocomplete` waits for previous `suggest` invocation to resolve or reject

Notes:
* I can imagine use cases where the choices would need to be updated spontaneously even if the user input didn't change.  This implementation doesn't support that
* It would be nice to one day support async paging (fetch more results as user moves toward end of already fetched results) but I haven't implemented it yet