### PR TITLE
Add opts.symbol to override symbol function

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -51,6 +51,7 @@ class AutocompletePrompt extends Prompt {
     this.complete = this.complete.bind(this);
     this.clear = clear('', this.out.columns);
     this.complete(this.render);
+    this.symbol = opts.symbol || style.symbol
     this.render();
   }
 
@@ -102,7 +103,7 @@ class AutocompletePrompt extends Prompt {
     if (this.clearFirst && this.input.length > 0) {
       this.reset();
     } else {
-      this.done = this.exited = true; 
+      this.done = this.exited = true;
       this.aborted = false;
       this.fire();
       this.render();
@@ -238,7 +239,7 @@ class AutocompletePrompt extends Prompt {
     let { startIndex, endIndex } = entriesToDisplay(this.select, this.choices.length, this.limit);
 
     this.outputText = [
-      style.symbol(this.done, this.aborted, this.exited),
+      this.symbol(this.done, this.aborted, this.exited, this.select),
       color.bold(this.msg),
       style.delimiter(this.completing),
       this.done && this.suggestions[this.select]

--- a/lib/elements/autocompleteMultiselect.js
+++ b/lib/elements/autocompleteMultiselect.js
@@ -23,6 +23,7 @@ class AutocompleteMultiselectPrompt extends MultiselectPrompt {
     this.inputValue = '';
     this.clear = clear('', this.out.columns);
     this.filteredOptions = this.value;
+    this.symbol = opts.symbol || style.symbol
     this.render();
   }
 
@@ -174,7 +175,7 @@ Filtered results for: ${this.inputValue ? this.inputValue : color.gray('Enter so
     // print prompt
 
     let prompt = [
-      style.symbol(this.done, this.aborted),
+      this.symbol(this.done, this.aborted, this.exited, this.filteredOptions),
       color.bold(this.msg),
       style.delimiter(false),
       this.renderDoneOrInstructions()

--- a/lib/elements/confirm.js
+++ b/lib/elements/confirm.js
@@ -25,6 +25,7 @@ class ConfirmPrompt extends Prompt {
     this.yesOption = opts.yesOption || '(Y/n)';
     this.noMsg = opts.no || 'no';
     this.noOption = opts.noOption || '(y/N)';
+    this.symbol = opts.symbol || style.symbol;
     this.render();
   }
 
@@ -75,7 +76,7 @@ class ConfirmPrompt extends Prompt {
     super.render();
 
     this.outputText = [
-      style.symbol(this.done, this.aborted),
+      this.symbol(this.done, this.aborted, this.exited, this.value),
       color.bold(this.msg),
       style.delimiter(this.done),
       this.done ? (this.value ? this.yesMsg : this.noMsg)

--- a/lib/elements/date.js
+++ b/lib/elements/date.js
@@ -51,6 +51,7 @@ class DatePrompt extends Prompt {
     this.validator = opts.validate || (() => true);
     this.mask = opts.mask || 'YYYY-MM-DD HH:mm:ss';
     this.clear = clear('', this.out.columns);
+    this.symbol = opts.symbol || style.symbol
     this.render();
   }
 
@@ -189,7 +190,7 @@ class DatePrompt extends Prompt {
 
     // Print prompt
     this.outputText = [
-      style.symbol(this.done, this.aborted),
+      this.symbol(this.done, this.aborted, this.exited, this.parts),
       color.bold(this.msg),
       style.delimiter(false),
       this.parts.reduce((arr, p, idx) => arr.concat(idx === this.cursor && !this.done ? color.cyan().underline(p.toString()) : p), [])

--- a/lib/elements/multiselect.js
+++ b/lib/elements/multiselect.js
@@ -43,6 +43,7 @@ class MultiselectPrompt extends Prompt {
       };
     });
     this.clear = clear('', this.out.columns);
+    this.symbol = opts.symbol || style.symbol
     if (!opts.overrideRender) {
       this.render();
     }
@@ -252,7 +253,7 @@ class MultiselectPrompt extends Prompt {
 
     // print prompt
     let prompt = [
-      style.symbol(this.done, this.aborted),
+      this.symbol(this.done, this.aborted, this.exited, this.value),
       color.bold(this.msg),
       style.delimiter(false),
       this.renderDoneOrInstructions()

--- a/lib/elements/number.js
+++ b/lib/elements/number.js
@@ -43,6 +43,7 @@ class NumberPrompt extends Prompt {
     this.value = ``;
     this.typed = ``;
     this.lastHit = 0;
+    this.symbol = opts.symbol || style.symbol
     this.render();
   }
 
@@ -193,7 +194,7 @@ class NumberPrompt extends Prompt {
 
     // Print prompt
     this.outputText = [
-      style.symbol(this.done, this.aborted),
+      this.symbol(this.done, this.aborted, this.exited, this.rendered),
       color.bold(this.msg),
       style.delimiter(this.done),
       !this.done || (!this.done && !this.placeholder)

--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -37,6 +37,7 @@ class SelectPrompt extends Prompt {
     this.optionsPerPage = opts.optionsPerPage || 10;
     this.value = (this.choices[this.cursor] || {}).value;
     this.clear = clear('', this.out.columns);
+    this.symbol = opts.symbol || style.symbol
     this.render();
   }
 
@@ -127,7 +128,7 @@ class SelectPrompt extends Prompt {
 
     // Print prompt
     this.outputText = [
-      style.symbol(this.done, this.aborted),
+      this.symbol(this.done, this.aborted, this.exited, this.selection),
       color.bold(this.msg),
       style.delimiter(false),
       this.done ? this.selection.title : this.selection.disabled

--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -26,6 +26,7 @@ class TextPrompt extends Prompt {
     this.errorMsg = opts.error || `Please Enter A Valid Value`;
     this.cursor = Number(!!this.initial);
     this.clear = clear(``, this.out.columns);
+    this.symbol = opts.symbol || style.symbol;
     this.render();
   }
 
@@ -167,7 +168,7 @@ class TextPrompt extends Prompt {
     this.outputError = '';
 
     this.outputText = [
-      style.symbol(this.done, this.aborted),
+      this.symbol(this.done, this.aborted, this.exited, this.rendered),
       color.bold(this.msg),
       style.delimiter(this.done),
       this.red ? color.red(this.rendered) : this.rendered

--- a/lib/elements/toggle.js
+++ b/lib/elements/toggle.js
@@ -21,6 +21,7 @@ class TogglePrompt extends Prompt {
     this.active = opts.active || 'on';
     this.inactive = opts.inactive || 'off';
     this.initialValue = this.value;
+    this.symbol = opts.symbol || style.symbol
     this.render();
   }
 
@@ -103,7 +104,7 @@ class TogglePrompt extends Prompt {
     super.render();
 
     this.outputText = [
-      style.symbol(this.done, this.aborted),
+      this.symbol(this.done, this.aborted, this.exited, this.value),
       color.bold(this.msg),
       style.delimiter(this.done),
       this.value ? this.inactive : color.cyan().underline(this.inactive),

--- a/readme.md
+++ b/readme.md
@@ -471,6 +471,7 @@ Hit <kbd>tab</kbd> to autocomplete to `initial` value when provided.
 | style | `string` | Render style (`default`, `password`, `invisible`, `emoji`). Defaults to `default` |
 | format | `function` | Receive user input. The returned value will be added to the response object |
 | validate | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
+| symbol | `function => function` | Symbol rendered before each prompt. Function signature is () => (done, aborted, exited, value) => string. Default is "?" if waiting, "✓" if done, and "✖" if aborted. |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -572,6 +573,7 @@ You can type in numbers and use <kbd>up</kbd>/<kbd>down</kbd> to increase/decrea
 | round | `number` | Round `float` values to x decimals. Defaults to `2` |
 | increment | `number` | Increment step when using <kbd>arrow</kbd> keys. Defaults to `1` |
 | style | `string` | Render style (`default`, `password`, `invisible`, `emoji`). Defaults to `default` |
+| symbol | `function => function` | Symbol rendered before each prompt. Function signature is () => (done, aborted, exited, value) => string. Default is "?" if waiting, "✓" if done, and "✖" if aborted. |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -603,6 +605,7 @@ Hit <kbd>y</kbd> or <kbd>n</kbd> to confirm/reject.
 | message | `string` | Prompt message to display |
 | initial | `boolean` | Default value. Default is `false` |
 | format | `function` | Receive user input. The returned value will be added to the response object |
+| symbol | `function => function` | Symbol rendered before each prompt. Function signature is () => (done, aborted, exited, value) => string. Default is "?" if waiting, "✓" if done, and "✖" if aborted. |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -669,6 +672,7 @@ Use tab or <kbd>arrow keys</kbd>/<kbd>tab</kbd>/<kbd>space</kbd> to switch betwe
 | format | `function` | Receive user input. The returned value will be added to the response object |
 | active | `string` | Text for `active` state. Defaults to `'on'` |
 | inactive | `string` | Text for `inactive` state. Defaults to `'off'` |
+| symbol | `function => function` | Symbol rendered before each prompt. Function signature is () => (done, aborted, exited, value) => string. Default is "?" if waiting, "✓" if done, and "✖" if aborted. |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -707,6 +711,7 @@ Use <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the l
 | hint | `string` | Hint to display to the user |
 | warn | `string` | Message to display when selecting a disabled option |
 | choices | `Array` | Array of strings or choices objects `[{ title, description, value, disabled }, ...]`. The choice's index in the array will be used as its value if it is not specified. |
+| symbol | `function => function` | Symbol rendered before each prompt. Function signature is () => (done, aborted, exited, selection) => string. Default is "?" if waiting, "✓" if done, and "✖" if aborted. |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -716,7 +721,7 @@ Use <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the l
 
 ### multiselect(message, choices, [initial], [max], [hint], [warn])
 ### autocompleteMultiselect(same)
-> Interactive multi-select prompt.  
+> Interactive multi-select prompt.
 > Autocomplete is a searchable multiselect prompt with the same options. Useful for long lists.
 
 Use <kbd>space</kbd> to toggle select/unselect and <kbd>up</kbd>/<kbd>down</kbd> to navigate. Use <kbd>tab</kbd> to cycle the list. You can also use <kbd>right</kbd> to select and <kbd>left</kbd> to deselect.
@@ -752,6 +757,7 @@ By default this prompt returns an `array` containing the **values** of the selec
 | max | `number` | Max select |
 | hint | `string` | Hint to display to the user |
 | warn | `string` | Message to display when selecting a disabled option |
+| symbol | `function => function` | Symbol rendered before each prompt. Function signature is () => (done, aborted, exited, filteredOptions) => string. Default is "?" if waiting, "✓" if done, and "✖" if aborted. |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -801,6 +807,7 @@ You can overwrite how choices are being filtered by passing your own suggest fun
 | initial | `string \| number` | Default initial value |
 | clearFirst | `boolean` | The first ESCAPE keypress will clear the input |
 | fallback | `string` | Fallback message when no match is found. Defaults to `initial` value if provided |
+| symbol | `function => function` | Symbol rendered before each prompt. Function signature is () => (done, aborted, exited, select) => string. Default is "?" if waiting, "✓" if done, and "✖" if aborted. |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with three properties: `value`, `aborted` and `exited` |
 
@@ -840,6 +847,7 @@ Use <kbd>left</kbd>/<kbd>right</kbd>/<kbd>tab</kbd> to navigate. Use <kbd>up</kb
 | locales | `object` | Use to define custom locales. See below for an example. |
 | mask | `string` | The format mask of the date. See below for more information.<br />Default: `YYYY-MM-DD HH:mm:ss` |
 | validate | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
+| symbol | `function => function` | Symbol rendered before each prompt. Function signature is () => (done, aborted, exited, parts) => string. Default is "?" if waiting, "✓" if done, and "✖" if aborted. |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 


### PR DESCRIPTION
### Problem

In some libraries, such as [npm-check-updates](https://github.com/raineorshine/npm-check-updates), it would be more intuitive to render `✓` when the user chooses yes, and `✖` when the user chooses no, rather than the default `✓` when done and `✖` when aborting.

### Solution

I added a `symbol` option that allows the user to override `style.symbol`.

Personally I only need it for `confirm`, but it seemed weird to not have it on all types, so that's the direction I went. I tried to pass the relevant value in each case, but I guessed in a few places since the variables are different types and names, so please correct me if any are wrong.