### PR TITLE
Changed cumbersome use of Array.prototype.indexOf

### DIFF
--- a/lib/elements/prompt.js
+++ b/lib/elements/prompt.js
@@ -23,7 +23,7 @@ class Prompt extends EventEmitter {
     readline.emitKeypressEvents(this.in, rl);
 
     if (this.in.isTTY) this.in.setRawMode(true);
-    const isSelect = [ 'SelectPrompt', 'MultiselectPrompt' ].indexOf(this.constructor.name) > -1;
+    const isSelect = [ 'SelectPrompt', 'MultiselectPrompt' ].includes(this.constructor.name);
     const keypress = (str, key) => {
       let a = action(key, isSelect);
       if (a === false) {


### PR DESCRIPTION
Changed from using Array.prototype.indexOf to the more fitting Array.prototype.includes method.