### PR TITLE
Add countable multiselect

### DIFF
--- a/lib/elements/countableMultiselect.js
+++ b/lib/elements/countableMultiselect.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const MultiselectPrompt = require('./multiselect');
+const { figures } = require('../util');
+/**
+ * MultiselectPrompt Base Element
+ * @param {Object} opts Options
+ * @param {String} opts.message Message
+ * @param {Array} opts.choices Array of choice objects
+ * @param {String} [opts.hint] Hint to display
+ * @param {String} [opts.warn] Hint shown for disabled choices
+ * @param {Number} [opts.max] Max choices
+ * @param {Number} [opts.cursor=0] Cursor start position
+ * @param {Stream} [opts.stdin] The Readable stream to listen to
+ * @param {Stream} [opts.stdout] The Writable stream to write readline data to
+ */
+class CountableMultiselectPrompt extends MultiselectPrompt {
+  constructor(opts={}) {
+    opts.overrideRender = true;
+    super(opts);
+
+    for (const item of this.value) {
+      item.count = 0;
+    }
+
+    this.render();
+  }
+
+  updateCount(increment) {
+    const item = this.value[this.cursor];
+    item.count = Math.max(0, item.count + increment);
+    item.selected = item.count > 0;
+    this.render();
+  }
+
+  left() {
+    this.updateCount(-1);
+  }
+
+  right() {
+    this.updateCount(1);
+  }
+
+  renderInstructions() {
+    const text = super.renderInstructions();
+    return text.replace('Toggle selection', 'Increment/decrement value').replace('    a: Toggle all\n', '');
+  }
+
+  renderOption(cursor, v, i, arrowIndicator) {
+    const text = super.renderOption(cursor, v, i, arrowIndicator);
+    return text.replace(figures.radioOn, v.count).replace(figures.radioOff, v.count);
+  }
+
+  _() {
+    // Do nothing.
+  }
+}
+
+module.exports = CountableMultiselectPrompt;

--- a/lib/elements/index.js
+++ b/lib/elements/index.js
@@ -9,5 +9,6 @@ module.exports = {
   MultiselectPrompt: require('./multiselect'),
   AutocompletePrompt: require('./autocomplete'),
   AutocompleteMultiselectPrompt: require('./autocompleteMultiselect'),
+  CountableMultiselectPrompt: require('./countableMultiselect'),
   ConfirmPrompt: require('./confirm')
 };

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -180,6 +180,15 @@ $.autocompleteMultiselect = args => {
   });
 };
 
+$.countableMultiselect = args => {
+  args.choices = [].concat(args.choices || []);
+  const toSelected = items => items.filter(item => item.selected).map(item => [item.value, item.count]);
+  return toPrompt('CountableMultiselectPrompt', args, {
+    onAbort: toSelected,
+    onSubmit: toSelected
+  });
+}
+
 const byTitle = (input, choices) => Promise.resolve(
   choices.filter(item => item.title.slice(0, input.length).toLowerCase() === input.toLowerCase())
 );


### PR DESCRIPTION
Hey! This PR allows a `countableMultiselect` element that looks something like this:

![image](https://user-images.githubusercontent.com/3929133/128921348-67e9f8f6-3315-4524-8cb8-87c7b40a7c64.png)

It's like `multiselect` but left/right arrows allow to increment or decrement a number. The option is considered "selected" when the number is greater than 0.

Let me know if you consider this a nice addition, if so I'll add the documentation and tests. Otherwise feel free to close this. Cheers!