### PR TITLE
Handle CTRL+U as reset

### DIFF
--- a/lib/util/action.js
+++ b/lib/util/action.js
@@ -9,6 +9,7 @@ module.exports = (key, isSelect) => {
     if (key.name === 'd') return 'abort';
     if (key.name === 'e') return 'last';
     if (key.name === 'g') return 'reset';
+    if (key.name === 'u') return 'reset';
   }
   
   if (isSelect) {


### PR DESCRIPTION
This PR defines CTRL+U as an additional `reset` shortcut. The point is to mimic Readline shortcut and to avoid having a `\u0015` NAK character prepended to the value as per the current implementation.