### PR TITLE
Optional number reset

### DIFF
--- a/lib/elements/number.js
+++ b/lib/elements/number.js
@@ -43,6 +43,7 @@ class NumberPrompt extends Prompt {
     this.value = ``;
     this.typed = ``;
     this.lastHit = 0;
+    this.resetDelay = opts.resetDelay || -1;
     this.render();
   }
 
@@ -56,6 +57,7 @@ class NumberPrompt extends Prompt {
       this.rendered = this.transform.render(`${round(v, this.round)}`);
       this._value = round(v, this.round);
     }
+    this.typed = this._value
     this.fire();
   }
 
@@ -167,7 +169,7 @@ class NumberPrompt extends Prompt {
     if (!this.valid(c)) return this.bell();
 
     const now = Date.now();
-    if (now - this.lastHit > 1000) this.typed = ``; // 1s elapsed
+    if (this.resetDelay > 0 && now - this.lastHit > this.resetDelay) this.typed = ``;
     this.typed += c;
     this.lastHit = now;
     this.color = `cyan`;

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -70,6 +70,7 @@ $.invisible = args => {
  * @param {Boolean} [opts.float=false] Parse input as floats
  * @param {Number} [opts.round=2] Round floats to x decimals
  * @param {Number} [opts.increment=1] Number to increment by when using arrow-keys
+ * @param {Number} [opts.resetDelay=-1] Milliseconds until input is automatically reset
  * @param {function} [args.validate] Function to validate user input
  * @param {Stream} [args.stdin] The Readable stream to listen to
  * @param {Stream} [args.stdout] The Writable stream to write readline data to

--- a/readme.md
+++ b/readme.md
@@ -571,6 +571,7 @@ You can type in numbers and use <kbd>up</kbd>/<kbd>down</kbd> to increase/decrea
 | float | `boolean` | Allow floating point inputs. Defaults to `false` |
 | round | `number` | Round `float` values to x decimals. Defaults to `2` |
 | increment | `number` | Increment step when using <kbd>arrow</kbd> keys. Defaults to `1` |
+| resetDelay | `number` | Milliseconds to wait before the input is automatically reset. Defaults to `-1` (disabled)
 | style | `string` | Render style (`default`, `password`, `invisible`, `emoji`). Defaults to `default` |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |


### PR DESCRIPTION
This PR resolves #307 and addresses aspects of #228

### Changes
1. Adds a `resetDelay` option to the Number prompt. Updates documentation.
2. By default, _disables_ the automatic reset behavior. Like others, I think this is more intuitive, but I am open to maintaining the original behavior if this is considered a breaking change.
3.  Fixes an issue where deleting/erasing number input would not sync the `typed` value. This made it impossible to actually delete input which is now potentially necessary.