### PR TITLE
Fix quiet crash select

### DIFF
--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -22,7 +22,7 @@ class SelectPrompt extends Prompt {
     this.msg = opts.message;
     this.hint = opts.hint || '- Use arrow-keys. Return to submit.';
     this.warn = opts.warn || '- This option is disabled';
-    this.cursor = opts.initial || 0;
+    this.cursor = (typeof opts.initial === 'number' && 0 <= opts.initial && opts.initial < this.choices.length) ? opts.initial : 0;
     this.choices = opts.choices.map((ch, idx) => {
       if (typeof ch === 'string')
         ch = {title: ch, value: idx};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
-        "kleur": "^3.0.3",
+        "kleur": "^4.0.1",
         "sisteransi": "^1.0.5"
       },
       "devDependencies": {
@@ -2637,9 +2637,9 @@
       }
     },
     "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
       "engines": {
         "node": ">=6"
       }
@@ -5534,9 +5534,9 @@
       }
     },
     "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
     },
     "load-json-file": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "interact"
   ],
   "dependencies": {
-    "kleur": "^3.0.3",
+    "kleur": "^4.0.1",
     "sisteransi": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
```js
var prompts = require("prompts")
prompts({
  type: 'select',
// initial greater than choices's size or initial is string will crash
  initial: 9,
  message: 'Hello world',
  choices: [
    {title: 'Python', value: 'py'},
    {title: 'C++', value: 'cpp'},
    {title: 'NodeJS', value: 'js'},
  ]
}).then(console.log)
```

crash case