### PR TITLE
fix(select): crash if initial isNaN (ex: string)

### DIFF
--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -22,7 +22,7 @@ class SelectPrompt extends Prompt {
     this.msg = opts.message;
     this.hint = opts.hint || '- Use arrow-keys. Return to submit.';
     this.warn = opts.warn || '- This option is disabled';
-    this.cursor = opts.initial || 0;
+    this.cursor = (typeof opts.initial === 'number' && 0 <= opts.initial && opts.initial < this.choices.length) ? opts.initial : 0;
     this.choices = opts.choices.map((ch, idx) => {
       if (typeof ch === 'string')
         ch = {title: ch, value: idx};


### PR DESCRIPTION
```js
var prompts = require("prompts")
prompts({
  type: 'select',
// initial greater than choices's size or initial is string will crash
  initial: 9,
  message: 'Hello world',
  choices: [
    {title: 'Python', value: 'py'},
    {title: 'C++', value: 'cpp'},
    {title: 'NodeJS', value: 'js'},
  ]
}).then(console.log)
```

crash case