### PR TITLE
Add heading support to select and multiselect

### DIFF
--- a/lib/elements/multiselect.js
+++ b/lib/elements/multiselect.js
@@ -22,7 +22,9 @@ class MultiselectPrompt extends Prompt {
   constructor(opts={}) {
     super(opts);
     this.msg = opts.message;
-    this.cursor = opts.cursor || 0;
+    // set the cursor to the first non-heading
+    this.cursorStart = opts.choices.findIndex(choice => !choice.heading);
+    this.cursor = opts.cursor || this.cursorStart;
     this.scrollIndex = opts.cursor || 0;
     this.hint = opts.hint || '';
     this.warn = opts.warn || '- This option is disabled -';
@@ -39,7 +41,8 @@ class MultiselectPrompt extends Prompt {
         description: ch && ch.description,
         value: ch && (ch.value === undefined ? idx : ch.value),
         selected: ch && ch.selected,
-        disabled: ch && ch.disabled
+        disabled: ch && ch.disabled,
+        heading: ch && ch.heading
       };
     });
     this.clear = clear('', this.out.columns);
@@ -50,7 +53,7 @@ class MultiselectPrompt extends Prompt {
 
   reset() {
     this.value.map(v => !v.selected);
-    this.cursor = 0;
+    this.cursor = this.cursorStart;
     this.fire();
     this.render();
   }
@@ -88,7 +91,7 @@ class MultiselectPrompt extends Prompt {
   }
 
   first() {
-    this.cursor = 0;
+    this.cursor = this.cursorStart
     this.render();
   }
 
@@ -98,23 +101,32 @@ class MultiselectPrompt extends Prompt {
   }
   next() {
     this.cursor = (this.cursor + 1) % this.value.length;
+    if (this.value[this.cursor].heading) {
+      this.next();
+    }
     this.render();
   }
 
   up() {
-    if (this.cursor === 0) {
+    if (this.cursor === this.cursorStart) {
       this.cursor = this.value.length - 1;
     } else {
       this.cursor--;
+      if (this.value[this.cursor].heading) {
+        this.up();
+      }
     }
     this.render();
   }
 
   down() {
     if (this.cursor === this.value.length - 1) {
-      this.cursor = 0;
+      this.cursor = this.cursorStart;
     } else {
       this.cursor++;
+      if (this.value[this.cursor].heading) {
+        this.down();
+      }
     }
     this.render();
   }
@@ -150,7 +162,7 @@ class MultiselectPrompt extends Prompt {
     }
 
     const newSelected = !this.value[this.cursor].selected;
-    this.value.filter(v => !v.disabled).forEach(v => v.selected = newSelected);
+    this.value.filter(v => !v.disabled && !v.heading).forEach(v => v.selected = newSelected);
     this.render();
   }
 
@@ -184,7 +196,12 @@ class MultiselectPrompt extends Prompt {
 
     if (v.disabled) {
       title = cursor === i ? color.gray().underline(v.title) : color.strikethrough().gray(v.title);
-    } else {
+    }
+    else if(v.heading) {
+      title = v.title
+      return title + color.gray(desc || '');
+    }
+    else {
       title = cursor === i ? color.cyan().underline(v.title) : v.title;
       if (cursor === i && v.description) {
         desc = ` - ${v.description}`;


### PR DESCRIPTION
Add `heading` property to the choices array to allow non-interactive headings.

Fixes #305

## Usage

```
  const result = await prompt({
    choices: [
      { title: 'Heading 1', heading: true },
      { title: 'a', selected: true },
      { title: 'b', selected: true },
      { title: 'c', selected: true },
      { title: 'Heading 2', heading: true },
      { title: 'd', selected: false },
      { title: 'e', selected: false },
      { title: 'f', selected: false },
    ],
    type: 'multiselect',
    hint: 'Headings are not selectable.',
    instructions: false,
    message: 'Choose an option',
    name: 'value',
  })
```

<img width="321" alt="image" src="https://user-images.githubusercontent.com/750276/174163436-ca2f26d4-29da-4e76-99e9-e34469d551ee.png">

## To Do

- [ ] select
- [x] multiselect
- [ ] automultiselect
- [ ] tests
- [ ] docs