### PR TITLE
feat: allow ctrl+j/k for navigation in autocomplete

### DIFF
--- a/lib/util/action.js
+++ b/lib/util/action.js
@@ -9,6 +9,8 @@ module.exports = (key, isSelect) => {
     if (key.name === 'd') return 'abort';
     if (key.name === 'e') return 'last';
     if (key.name === 'g') return 'reset';
+    if (key.name === 'j') return 'down';
+    if (key.name === 'k') return 'up';
   }
   
   if (isSelect) {


### PR DESCRIPTION
We switched a select to an autocomplete in our CLI tool (withgraphite/graphite-cli) without realizing that j/k work for up/down!  One of our users suggested this as a compromise and noted that

> This matches other CLI tools such as `fzf`!