### PR TITLE
Change up/down for number to use initial value

### DIFF
--- a/lib/elements/number.js
+++ b/lib/elements/number.js
@@ -124,7 +124,8 @@ class NumberPrompt extends Prompt {
   up() {
     this.typed = ``;
     if(this.value === '') {
-      this.value = this.min - this.inc;
+      const base = this.initial === "" ? this.min : this.initial;
+      this.value = base - this.inc;
     }
     if (this.value >= this.max) return this.bell();
     this.value += this.inc;
@@ -136,7 +137,8 @@ class NumberPrompt extends Prompt {
   down() {
     this.typed = ``;
     if(this.value === '') {
-      this.value = this.min + this.inc;
+      const base = this.initial === "" ? this.min : this.initial;
+      this.value = base + this.inc;
     }
     if (this.value <= this.min) return this.bell();
     this.value -= this.inc;


### PR DESCRIPTION
This is a small change to make the up/down behaviour a little bit more natural.

Use case:
```typescript
const {xMovement} = await prompts(
  {
    type: 'number',
    name: 'xMovement',
    message: 'How should the asset move horizontally (x)?',
    initial: 0
  }
);
```

Repro steps
1. Run above example code
2. See initial 'grayed out' `0` where value is displayed
3. Without inputting any new values, press ↑ _(up)_

Expected result: input value to change in regards to the `0`
Actual result: input value is set to `-Infinity`

New behaviour: pressing ↑ _(up)_ sets the value (cyan) to 0, pressing ↑ _(up)_ again changes the value to 1

Ditto for pressing ↓ _(down)_