### PR TITLE
Reject toPrompt Promise when 'exit' is emitted.

### DIFF
--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -11,7 +11,7 @@ function toPrompt(type, args, opts={}) {
     const onExit = opts.onExit || noop;
     p.on('state', args.onState || noop);
     p.on('submit', x => res(onSubmit(x)));
-    p.on('exit', x => res(onExit(x)));
+    p.on('exit', x => rej(onExit(x)));
     p.on('abort', x => rej(onAbort(x)));
   });
 }


### PR DESCRIPTION
Resolves #362

This fixes the 'autocomplete' prompt incorrectly firing onSubmit when it is exitted by pressing ESC. Now correctly fires onCancel.