### PR TITLE
Migrate type definitions from DefinitelyTyped

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,120 @@
+// Definitions migrated from DefinitelyTyped.
+//
+// Special Thanks to: Berkay GURSOY <https://github.com/Berkays>
+//                    Daniel Perez Alvarez <https://github.com/unindented>
+//                    Kamontat Chantrachirathumrong <https://github.com/kamontat>
+//                    theweirdone <https://github.com/theweirdone>
+//                    whoaa512 <https://github.com/whoaa512>
+//                    John Reilly <https://github.com/johnnyreilly>
+//                    Christopher Hiller <https://github.com/boneskull>
+
+
+export = prompts;
+
+import { Readable, Writable } from 'stream';
+import { Kleur } from 'kleur';
+
+declare function prompts<T extends string = string>(
+	questions: prompts.PromptObject<T> | Array<prompts.PromptObject<T>>,
+	options?: prompts.Options
+): Promise<prompts.Answers<T>>;
+
+declare namespace prompts {
+	// Circular reference from prompts
+	const prompt: any;
+
+	function inject(arr: ReadonlyArray<any>): void;
+
+	namespace inject {
+		const prototype: {};
+	}
+
+	function override(obj: { [key: string]: any }): void;
+
+	namespace override {
+		const prototype: {};
+	}
+
+	namespace prompts {
+		function autocomplete(args: PromptObject): any;
+
+		function confirm(args: PromptObject): void;
+
+		function date(args: PromptObject): any;
+
+		function invisible(args: PromptObject): any;
+
+		function list(args: PromptObject): any;
+
+		function multiselect(args: PromptObject): any;
+
+		function number(args: PromptObject): void;
+
+		function password(args: PromptObject): any;
+
+		function select(args: PromptObject): void;
+
+		function text(args: PromptObject): void;
+
+		function toggle(args: PromptObject): void;
+	}
+
+	// Based upon: https://github.com/terkelg/prompts/blob/d7d2c37a0009e3235b2e88a7d5cdbb114ac271b2/lib/elements/select.js#L29
+	interface Choice {
+		title: string;
+		value?: any;
+		disabled?: boolean | undefined;
+		selected?: boolean | undefined;
+		description?: string | undefined;
+	}
+
+	interface Options {
+		onSubmit?: ((prompt: PromptObject, answer: any, answers: any[]) => void) | undefined;
+		onCancel?: ((prompt: PromptObject, answers: any) => void) | undefined;
+	}
+
+	interface PromptObject<T extends string = string> {
+		type: PromptType | Falsy | PrevCaller<T, PromptType | Falsy>;
+		name: ValueOrFunc<T>;
+		message?: ValueOrFunc<string> | undefined;
+		initial?: InitialReturnValue | PrevCaller<T, InitialReturnValue | Promise<InitialReturnValue>> | undefined;
+		style?: string | PrevCaller<T, string | Falsy> | undefined;
+		format?: PrevCaller<T, void> | undefined;
+		validate?: PrevCaller<T, boolean | string | Promise<boolean | string>> | undefined;
+		onState?: PrevCaller<T, void> | undefined;
+		onRender?: ((kleur: Kleur) => void) | undefined;
+		min?: number | PrevCaller<T, number | Falsy> | undefined;
+		max?: number | PrevCaller<T, number | Falsy> | undefined;
+		float?: boolean | PrevCaller<T, boolean | Falsy> | undefined;
+		round?: number | PrevCaller<T, number | Falsy> | undefined;
+		instructions?: string | boolean | undefined;
+		increment?: number | PrevCaller<T, number | Falsy> | undefined;
+		separator?: string | PrevCaller<T, string | Falsy> | undefined;
+		active?: string | PrevCaller<T, string | Falsy> | undefined;
+		inactive?: string | PrevCaller<T, string | Falsy> | undefined;
+		choices?: Choice[] | PrevCaller<T, Choice[] | Falsy> | undefined;
+		hint?: string | PrevCaller<T, string | Falsy> | undefined;
+		warn?: string | PrevCaller<T, string | Falsy> | undefined;
+		suggest?: ((input: any, choices: Choice[]) => Promise<any>) | undefined;
+		limit?: number | PrevCaller<T, number | Falsy> | undefined;
+		mask?: string | PrevCaller<T, string | Falsy> | undefined;
+		stdout?: Writable | undefined;
+		stdin?: Readable | undefined;
+	}
+
+	type Answers<T extends string> = { [id in T]: any };
+
+	type PrevCaller<T extends string, R = T> = (
+		prev: any,
+		values: Answers<T>,
+		prompt: PromptObject
+	) => R;
+
+	type Falsy = false | null | undefined;
+
+	type PromptType = "text" | "password" | "invisible" | "number" | "confirm" | "list" | "toggle" | "select" | "multiselect" | "autocomplete" | "date" | "autocompleteMultiselect";
+
+	type ValueOrFunc<T extends string> = T | PrevCaller<T>;
+
+	type InitialReturnValue = string | number | boolean | Date;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
         "@babel/preset-env": "^7.12.1",
         "tap-spec": "^2.2.2",
-        "tape": "^4.13.3"
+        "tape": "^4.13.3",
+        "typescript": "^4.9.4"
       },
       "engines": {
         "node": ">= 6"
@@ -3577,6 +3578,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -6285,6 +6299,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@babel/core": "^7.12.3",
         "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
         "@babel/preset-env": "^7.12.1",
+        "@types/node": "^18.11.17",
         "tap-spec": "^2.2.2",
         "tape": "^4.13.3",
         "typescript": "^4.9.4"
@@ -1583,6 +1584,12 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+      "dev": true
     },
     "node_modules/ansi-regex": {
       "version": "2.1.1",
@@ -4769,6 +4776,12 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
       "optional": true
+    },
+    "@types/node": {
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "node lib/index.js",
     "build": "babel lib -d dist",
     "prepublishOnly": "npm run build",
-    "test": "tape test/*.js | tap-spec"
+    "test": "tape test/*.js | tap-spec",
+    "test-types": "tsc --noEmit test/type-declarations.ts"
   },
   "keywords": [
     "ui",
@@ -45,7 +46,8 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "tap-spec": "^2.2.2",
-    "tape": "^4.13.3"
+    "tape": "^4.13.3",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
+    "@types/node": "^18.11.17",
     "tap-spec": "^2.2.2",
     "tape": "^4.13.3",
     "typescript": "^4.9.4"

--- a/test/type-declarations.ts
+++ b/test/type-declarations.ts
@@ -1,0 +1,206 @@
+import * as prompts from '../index';
+
+type HasProperty<T, K> = K extends keyof T ? true : false;
+
+(async () => {
+	const response = await prompts({
+		type: 'number',
+		name: 'value',
+		message: 'Input value to double:',
+		validate: (value: any) => (value < 0 ? `Cant be less than zero` : true),
+	});
+	const HasPropValue: HasProperty<typeof response, 'value'> = true;
+	const DoesntHavePropAsdf: HasProperty<typeof response, 'asdf'> = false;
+})();
+
+(async () => {
+	await prompts([
+		{
+			type: 'text',
+			name: 'language',
+			message: 'What langauge is the next greatest thing since sliced bread?',
+		},
+		{
+			type: (prev, values) => {
+				const HasPromptName: HasProperty<typeof values, 'language'> = true;
+				const DoesntHavePromptTypes: HasProperty<typeof values, 'text'> = false;
+
+				return prev === 'javascript' ? 'confirm' : null;
+			},
+			name: 'confirmation',
+			message: 'Have you tried TypeScript?',
+		},
+		{
+			type: 'select',
+			name: 'so-many-options',
+			message: 'options, options!!',
+			choices: [
+				{
+					title: 'A',
+					value: 'A',
+				},
+				{
+					title: 'B',
+					value: { foo: 'bar' },
+				},
+				{
+					title: 'C',
+					value: 'C',
+					disabled: false,
+					selected: false,
+					description: 'a description',
+				},
+			],
+			warn: 'Warning, option is disabled'
+		},
+		{
+			type: 'multiselect',
+			name: 'choices',
+			message: `why don't we have both?`,
+			instructions: false,
+			choices: [
+				{
+					value: 'A',
+					title: 'A',
+				},
+				{
+					value: 'B',
+					title: 'B',
+				},
+			],
+			warn: 'Warning, option is disabled'
+		},
+	]);
+})();
+
+(async () => {
+	await prompts([
+		{
+			type: 'select',
+			name: 'choices',
+			instructions: false,
+			message: 'options, options!!',
+			choices: [
+				{
+					value: 'A',
+					title: 'A',
+				},
+				{
+					title: 'B',
+				},
+			],
+			warn: 'Warning, option is disabled'
+		},
+		{
+			type: 'select',
+			name: 'subchoices',
+			message: 'optionception!',
+			choices: (prev) => {
+				return [
+					{
+						value: prev + 'A',
+						title: prev + 'A',
+					},
+					{
+						value: prev + 'B',
+						title: prev + 'B',
+					},
+				];
+			},
+		},
+	]);
+})();
+
+// test for PromptObject.initial
+(async () => {
+	await prompts({
+		type: 'text',
+		name: 'value',
+		message: 'string',
+		initial: 'string'
+	});
+
+	await prompts({
+		type: 'number',
+		name: 'value',
+		message: 'number',
+		initial: 0
+	});
+
+	await prompts({
+		type: 'confirm',
+		name: 'value',
+		message: 'boolean',
+		initial: true
+	});
+
+	await prompts({
+		type: 'date',
+		name: 'value',
+		message: 'date',
+		initial: new Date()
+	});
+
+	await prompts({
+		type: 'text',
+		name: 'value',
+		message: 'function => string',
+		initial: () => 'initial value'
+	});
+
+	await prompts({
+		type: 'number',
+		name: 'value',
+		message: 'function => number',
+		initial: () => 1
+	});
+
+	await prompts({
+		type: 'confirm',
+		name: 'value',
+		message: 'function => boolean',
+		initial: () => true
+	});
+
+	await prompts({
+		type: 'date',
+		name: 'value',
+		message: 'function => date',
+		initial: () => new Date()
+	});
+
+	await prompts({
+		type: 'date',
+		name: 'value',
+		message: 'function => date',
+		initial: () => new Date()
+	});
+
+	await prompts({
+		type: 'text',
+		name: 'value',
+		message: 'async function => string',
+		initial: async () => 'initial value'
+	});
+
+	await prompts({
+		type: 'number',
+		name: 'value',
+		message: 'async function => number',
+		initial: async () => 1
+	});
+
+	await prompts({
+		type: 'confirm',
+		name: 'value',
+		message: 'async function => boolean',
+		initial: async () => true
+	});
+
+	await prompts({
+		type: 'date',
+		name: 'value',
+		message: 'async function => date',
+		initial: async () => new Date()
+	});
+})();


### PR DESCRIPTION
Closes #377
Closes #372 

Moves types from DefinitelyTyped to here. Original contributors are given credit as co-authors.

An additional npm script is included to run type declaration tests. 

@terkelg 