### PR TITLE
feat: pass answers to validator function

### DIFF
--- a/lib/elements/date.js
+++ b/lib/elements/date.js
@@ -115,7 +115,7 @@ class DatePrompt extends Prompt {
   }
 
   async validate() {
-    let valid = await this.validator(this.value);
+    let valid = await this.validator(this.value, this.answers);
     if (typeof valid === 'string') {
       this.errorMsg = valid;
       valid = false;

--- a/lib/elements/number.js
+++ b/lib/elements/number.js
@@ -94,7 +94,7 @@ class NumberPrompt extends Prompt {
   }
 
   async validate() {
-    let valid = await this.validator(this.value);
+    let valid = await this.validator(this.value, this.answers);
     if (typeof valid === `string`) {
       this.errorMsg = valid;
       valid = false;

--- a/lib/elements/prompt.js
+++ b/lib/elements/prompt.js
@@ -15,6 +15,7 @@ class Prompt extends EventEmitter {
   constructor(opts={}) {
     super();
 
+    this.answers = opts.answers || {};
     this.firstRender = true;
     this.in = opts.stdin || process.stdin;
     this.out = opts.stdout || process.stdout;

--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -70,7 +70,7 @@ class TextPrompt extends Prompt {
   }
 
   async validate() {
-    let valid = await this.validator(this.value);
+    let valid = await this.validator(this.value, this.answers);
     if (typeof valid === `string`) {
       this.errorMsg = valid;
       valid = false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
   let answer, question, quit, name, type, lastPrompt;
 
   const getFormattedAnswer = async (question, answer, skipValidation = false) => {
-    if (!skipValidation && question.validate && question.validate(answer) !== true) {
+    if (!skipValidation && question.validate && question.validate(answer, answers) !== true) {
       return;
     }
     return question.format ? await question.format(answer, answers) : answer
@@ -65,7 +65,7 @@ async function prompt(questions=[], { onSubmit=noop, onCancel=noop }={}) {
 
     try {
       // Get the injected answer if there is one or prompt the user
-      answer = prompt._injected ? getInjectedAnswer(prompt._injected, question.initial) : await prompts[type](question);
+      answer = prompt._injected ? getInjectedAnswer(prompt._injected, question.initial) : await prompts[type]({ ...question, answers });
       answers[name] = answer = await getFormattedAnswer(question, answer, true);
       quit = await onSubmit(question, answer, answers);
     } catch (err) {


### PR DESCRIPTION
This closes #273 

I don't consider this done yet, but I wanted to go ahead and take a stab at this and get some feedback. Tasks still remaining:

- since I'm here, should all elements support validation (#344 and others)? 
- update the docs

This is not my favortie implementation, but it's the best I could come up with short of a refactor. The crux of the problems is we need to pass the answers to all elements as they are constructed.