### PR TITLE
feat: list of buttons

### DIFF
--- a/example.js
+++ b/example.js
@@ -103,6 +103,17 @@ let interval;
                     this.render();
                 }, 1000);
             }
+        },
+        {
+            type: 'buttons',
+            name: 'action',
+            message: 'Do you want to proceed?',
+            choices: [
+                { title: 'Yes', description: 'This option has a description.', value: 'confirmed' },
+                { title: 'No', value: 'rejected' },
+                { title: 'Disabled', value: '-', disabled: true },
+                { title: 'Abort', value: 'aborted' }
+            ]
         }
     ];
 
@@ -113,4 +124,3 @@ let interval;
 function cleanup() {
     clearInterval(interval);
 }
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,8 @@ declare namespace prompts {
 		function text(args: PromptObject): void;
 
 		function toggle(args: PromptObject): void;
+
+		function buttons(args: PromptObject): void;
 	}
 
 	// Based upon: https://github.com/terkelg/prompts/blob/d7d2c37a0009e3235b2e88a7d5cdbb114ac271b2/lib/elements/select.js#L29
@@ -112,7 +114,7 @@ declare namespace prompts {
 
 	type Falsy = false | null | undefined;
 
-	type PromptType = "text" | "password" | "invisible" | "number" | "confirm" | "list" | "toggle" | "select" | "multiselect" | "autocomplete" | "date" | "autocompleteMultiselect";
+	type PromptType = "text" | "password" | "invisible" | "number" | "confirm" | "list" | "toggle" | "select" | "multiselect" | "autocomplete" | "date" | "autocompleteMultiselect" | "buttons";
 
 	type ValueOrFunc<T extends string> = T | PrevCaller<T>;
 

--- a/lib/elements/buttons.js
+++ b/lib/elements/buttons.js
@@ -141,15 +141,13 @@ class ButtonsPrompt extends Prompt {
       for (let i = startIndex; i < endIndex; i++) {
         let title, desc = '', v = this.choices[i];
 
+        const buttonLabel = ` ${v.title} `
+        const focusedBtn = v.disabled ? color.bgWhite().grey                  : color.bgWhite().red
+        const blurredBtn = v.disabled ? color.bgWhite().black().strikethrough : color.bgBlue().white
 
-        if (v.disabled) {
-          title = this.cursor === i ? color.black().bgWhite().underline(v.title) : color.strikethrough().bgWhite().grey(v.title);
-        } else {
-
-          title = this.cursor === i ? color.bgWhite().red(` ${v.title} `) : color.bgBlue().white(` ${v.title} `);
-          if (v.description && this.cursor === i) {
-            description = v.description;
-          }
+        title = this.cursor === i ? focusedBtn(buttonLabel) : blurredBtn(buttonLabel);
+        if (v.description && this.cursor === i) {
+          description = v.description;
         }
 
         this.outputText += ` ${title}${color.gray(desc)} `;

--- a/lib/elements/buttons.js
+++ b/lib/elements/buttons.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const color = require('kleur');
+const Prompt = require('./prompt');
+const { style, clear, entriesToDisplay } = require('../util');
+const { cursor } = require('sisteransi');
+
+/**
+ * ButtonsPrompt Base Element
+ * @param {Object} opts Options
+ * @param {String} opts.message Message
+ * @param {Array} opts.choices Array of choice objects
+ * @param {String} [opts.hint] Hint to display
+ * @param {Number} [opts.initial] Index of default value
+ * @param {Stream} [opts.stdin] The Readable stream to listen to
+ * @param {Stream} [opts.stdout] The Writable stream to write readline data to
+ * @param {Number} [opts.optionsPerPage=10] Max options to display at once
+ */
+class ButtonsPrompt extends Prompt {
+  constructor(opts={}) {
+    super(opts);
+    this.msg = opts.message;
+    this.hint = opts.hint || '- Use arrow-keys. Return to submit.';
+    this.warn = opts.warn || '- This option is disabled';
+    this.cursor = opts.initial || 0;
+    this.choices = opts.choices.map((ch, idx) => {
+      if (typeof ch === 'string')
+        ch = {title: ch, value: idx};
+      return {
+        title: ch && (ch.title || ch.value || ch),
+        value: ch && (ch.value === undefined ? idx : ch.value),
+        description: ch && ch.description,
+        selected: ch && ch.selected,
+        disabled: ch && ch.disabled
+      };
+    });
+    this.optionsPerPage = opts.optionsPerPage || 10;
+    this.value = (this.choices[this.cursor] || {}).value;
+    this.clear = clear('', this.out.columns);
+    this.render();
+  }
+
+  moveCursor(n) {
+    this.cursor = n;
+    this.value = this.choices[n].value;
+    this.fire();
+  }
+
+  reset() {
+    this.moveCursor(0);
+    this.fire();
+    this.render();
+  }
+
+  exit() {
+    this.abort();
+  }
+
+  abort() {
+    this.done = this.aborted = true;
+    this.fire();
+    this.render();
+    this.out.write('\n');
+    this.close();
+  }
+
+  submit() {
+    if (!this.selection.disabled) {
+      this.done = true;
+      this.aborted = false;
+      this.fire();
+      this.render();
+      this.out.write('\n');
+      this.close();
+    } else
+      this.bell();
+  }
+
+  first() {
+    this.moveCursor(0);
+    this.render();
+  }
+
+  last() {
+    this.moveCursor(this.choices.length - 1);
+    this.render();
+  }
+
+  left() {
+    if (this.cursor === 0) {
+      this.moveCursor(this.choices.length - 1);
+    } else {
+      this.moveCursor(this.cursor - 1);
+    }
+    this.render();
+  }
+
+  right() {
+    if (this.cursor === this.choices.length - 1) {
+      this.moveCursor(0);
+    } else {
+      this.moveCursor(this.cursor + 1);
+    }
+    this.render();
+  }
+
+  next() {
+    this.moveCursor((this.cursor + 1) % this.choices.length);
+    this.render();
+  }
+
+  _(c, key) {
+    if (c === ' ') return this.submit();
+  }
+
+  get selection() {
+    return this.choices[this.cursor];
+  }
+
+  render() {
+    if (this.closed) return;
+    if (this.firstRender) this.out.write(cursor.hide);
+    else this.out.write(clear(this.outputText, this.out.columns));
+    super.render();
+
+    let { startIndex, endIndex } = entriesToDisplay(this.cursor, this.choices.length, this.optionsPerPage);
+
+    // Print prompt
+    this.outputText = [
+      style.symbol(this.done, this.aborted),
+      color.bold(this.msg),
+      style.delimiter(false),
+      this.done ? this.selection.title : this.selection.disabled
+          ? color.yellow(this.warn) : color.gray(this.hint)
+    ].join(' ');
+
+    // Print choices
+    if (!this.done) {
+      this.outputText += '\n';
+      let description = false;
+      for (let i = startIndex; i < endIndex; i++) {
+        let title, desc = '', v = this.choices[i];
+
+
+        if (v.disabled) {
+          title = this.cursor === i ? color.black().bgWhite().underline(v.title) : color.strikethrough().bgWhite().grey(v.title);
+        } else {
+
+          title = this.cursor === i ? color.bgWhite().red(` ${v.title} `) : color.bgBlue().white(` ${v.title} `);
+          if (v.description && this.cursor === i) {
+            description = v.description;
+          }
+        }
+
+        this.outputText += ` ${title}${color.gray(desc)} `;
+      }
+      if (description) {
+        this.outputText += `\n ${description}`;
+      }
+    }
+
+    this.out.write(this.outputText);
+  }
+}
+
+module.exports = ButtonsPrompt;

--- a/lib/elements/index.js
+++ b/lib/elements/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   TextPrompt: require('./text'),
   SelectPrompt: require('./select'),
+  ButtonsPrompt: require('./buttons'),
   TogglePrompt: require('./toggle'),
   DatePrompt: require('./date'),
   NumberPrompt: require('./number'),

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -150,6 +150,8 @@ $.toggle = args => toPrompt('TogglePrompt', args);
  */
 $.select = args => toPrompt('SelectPrompt', args);
 
+$.buttons = args => toPrompt('ButtonsPrompt', args);
+
 /**
  * Interactive multi-select / autocompleteMultiselect prompt
  * @param {string} args.message Prompt message to display

--- a/readme.md
+++ b/readme.md
@@ -444,6 +444,7 @@ If you need to use different streams, for instance `process.stderr`, you can set
 * [autocompleteMultiselect](#multiselectmessage-choices-initial-max-hint-warn)
 * [autocomplete](#autocompletemessage-choices-initial-suggest-limit-style)
 * [date](#datemessage-initial-warn)
+* [buttons](#buttons)
 
 ***
 
@@ -870,6 +871,43 @@ Default locales:
 ![split](https://github.com/terkelg/prompts/raw/master/media/split.png)
 
 **↑ back to:** [Prompt types](#-types)
+
+### buttons(message, choices, [initial], [hint], [warn])
+> Horizontal list of buttons.
+
+Use <kbd>left</kbd>/<kbd>right</kbd> to navigate. Use <kbd>tab</kbd> to cycle.
+
+#### Example
+
+```js
+{
+  type: 'buttons',
+  name: 'action',
+  message: 'Do you want to proceed?',
+  choices: [
+    { title: 'Yes', description: 'This option has a description.', value: 'confirmed' },
+    { title: 'No', value: 'rejected' },
+    { title: 'Disabled', value: '-', disabled: true },
+    { title: 'Abort', value: 'aborted' }
+  ],
+  initial: 1
+}
+```
+
+#### Options
+| Param | Type | Description |
+| ----- | :--: | ----------- |
+| message | `string` | Prompt message to display |
+| initial | `number` | Index of default value |
+| format | `function` | Receive user input. The returned value will be added to the response object |
+| hint | `string` | Hint to display to the user |
+| warn | `string` | Message to display when selecting a disabled option |
+| choices | `Array` | Array of strings or choices objects `[{ title, description, value, disabled }, ...]`. The choice's index in the array will be used as its value if it is not specified. |
+| onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
+| onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
+
+**↑ back to:** [Prompt types](#-types)
+
 
 ***
 

--- a/test/prompts.js
+++ b/test/prompts.js
@@ -13,7 +13,7 @@ test('basics', t => {
 });
 
 test('prompts', t => {
-  t.plan(25);
+  t.plan(27);
 
   const types = [
     'text',
@@ -24,6 +24,7 @@ test('prompts', t => {
     'list',
     'toggle',
     'select',
+    'buttons',
     'multiselect',
     'autocompleteMultiselect',
     'autocomplete',

--- a/test/type-declarations.ts
+++ b/test/type-declarations.ts
@@ -70,6 +70,29 @@ type HasProperty<T, K> = K extends keyof T ? true : false;
 			],
 			warn: 'Warning, option is disabled'
 		},
+		{
+			type: 'buttons',
+			name: 'so-many-buttons',
+			message: 'buttons, buttons!!',
+			choices: [
+				{
+					title: 'A',
+					value: 'A',
+				},
+				{
+					title: 'B',
+					value: { foo: 'bar' },
+				},
+				{
+					title: 'C',
+					value: 'C',
+					disabled: false,
+					selected: false,
+					description: 'a description',
+				},
+			],
+			warn: 'Warning, option is disabled'
+		},
 	]);
 })();
 


### PR DESCRIPTION
Hi

I really like `prompts` for it simplicity and because "it just works" out of the box (I had a bad experience with `inquirer`). I'd love to use it in my recent project however I miss a horizontal list of buttons.

![inquirer-buttons](https://user-images.githubusercontent.com/7869474/212488917-376f5746-64ce-4f02-a1de-ba49afd58b7a.gif)

Here is my implementation. Please consider pulling it to the Prompts.
If you hesitate to do it I'd also be grateful for that information so I wouldn't wait.

Kind Regards
  Jarek
  
P.S. It would be awesome if Prompts would allow to plug-in custom components.  