### PR TITLE
autocomplete: Add option fallbackAsInput

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -22,6 +22,7 @@ const getIndex = (arr, valOrTitle) => {
  * @param {Number} [opts.cursor=0] Cursor start position
  * @param {String} [opts.style='default'] Render style
  * @param {String} [opts.fallback] Fallback message - initial to default value
+ * @param {Boolean} [opts.fallbackAsInput] Returns input value when no matches found
  * @param {String} [opts.initial] Index of the default value
  * @param {Boolean} [opts.clearFirst] The first ESCAPE keypress will clear the input
  * @param {Stream} [opts.stdin] The Readable stream to listen to
@@ -34,6 +35,7 @@ class AutocompletePrompt extends Prompt {
     this.msg = opts.message;
     this.suggest = opts.suggest;
     this.choices = opts.choices;
+    this.fallbackAsInput = opts.fallbackAsInput;
     this.initial = typeof opts.initial === 'number'
       ? opts.initial
       : getIndex(opts.choices, opts.initial);
@@ -64,14 +66,14 @@ class AutocompletePrompt extends Prompt {
       choice = this.choices[this._fb];
     else if (typeof this._fb === 'string')
       choice = { title: this._fb };
-    return choice || this._fb || { title: this.i18n.noMatches };
+    return this.fallbackAsInput ? {title:""} : choice || this._fb || { title: this.i18n.noMatches };
   }
 
   moveSelect(i) {
     this.select = i;
     if (this.suggestions.length > 0)
       this.value = getVal(this.suggestions, i);
-    else this.value = this.fallback.value;
+    else this.value = this.fallbackAsInput ? this.input : this.fallback.value;
     this.fire();
   }
 


### PR DESCRIPTION
Problem: Unable to submit the input value when matches not found.
Solution: Add a new option to return the input value when no matches found.