### PR TITLE
Fix "validate" vs "validator" name issue in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ const prompts = require('prompts');
     type: 'number',
     name: 'value',
     message: 'How old are you?',
-    validate: value => value < 18 ? `Nightclub is 18+ only` : true
+    validator: value => value < 18 ? `Nightclub is 18+ only` : true
   });
 
   console.log(response); // => { value: 24 }
@@ -470,7 +470,7 @@ Hit <kbd>tab</kbd> to autocomplete to `initial` value when provided.
 | initial | `string` | Default string value |
 | style | `string` | Render style (`default`, `password`, `invisible`, `emoji`). Defaults to `default` |
 | format | `function` | Receive user input. The returned value will be added to the response object |
-| validate | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
+| validator | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -500,7 +500,7 @@ This prompt is a similar to a prompt of type `'text'` with `style` set to `'pass
 | message | `string` | Prompt message to display |
 | initial | `string` | Default string value |
 | format | `function` | Receive user input. The returned value will be added to the response object |
-| validate | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
+| validator | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -531,7 +531,7 @@ This prompt is a similar to a prompt of type `'text'` with style set to `'invisi
 | message | `string` | Prompt message to display |
 | initial | `string` | Default string value |
 | format | `function` | Receive user input. The returned value will be added to the response object |
-| validate | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
+| validator | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 
@@ -565,7 +565,7 @@ You can type in numbers and use <kbd>up</kbd>/<kbd>down</kbd> to increase/decrea
 | message | `string` | Prompt message to display |
 | initial | `number` | Default number value |
 | format | `function` | Receive user input. The returned value will be added to the response object |
-| validate | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
+| validator | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
 | max | `number` | Max value. Defaults to `Infinity` |
 | min | `number` | Min value. Defaults to `-infinity` |
 | float | `boolean` | Allow floating point inputs. Defaults to `false` |
@@ -828,7 +828,7 @@ Use <kbd>left</kbd>/<kbd>right</kbd>/<kbd>tab</kbd> to navigate. Use <kbd>up</kb
   name: 'value',
   message: 'Pick a date',
   initial: new Date(1997, 09, 12),
-  validate: date => date > Date.now() ? 'Not in the future' : true
+  validator: date => date > Date.now() ? 'Not in the future' : true
 }
 ```
 
@@ -839,7 +839,7 @@ Use <kbd>left</kbd>/<kbd>right</kbd>/<kbd>tab</kbd> to navigate. Use <kbd>up</kb
 | initial | `date` | Default date |
 | locales | `object` | Use to define custom locales. See below for an example. |
 | mask | `string` | The format mask of the date. See below for more information.<br />Default: `YYYY-MM-DD HH:mm:ss` |
-| validate | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
+| validator | `function` | Receive user input. Should return `true` if the value is valid, and an error message `String` otherwise. If `false` is returned, a default error message is shown |
 | onRender | `function` | On render callback. Keyword `this` refers to the current prompt |
 | onState | `function` | On state change callback. Function signature is an `object` with two properties: `value` and `aborted` |
 


### PR DESCRIPTION
Hello there!

When trying to use `prompts`, and copy + pasting from your own documentation, I ran into an exception thrown deep inside the `prompts` library:

Using your exact first example (or almost exact... I am using native ES6 modules):

```javascript
import prompts from 'prompts';

(async () => {
  const response = await prompts({
    type: 'number',
    name: 'value',
    message: 'How old are you?',
    validate: value => value < 18 ? `Nightclub is 18+ only` : true
  });

  console.log(response); // => { value: 24 }
})();
```

This is the result:

```bash
? How old are you? › 23
    let valid = await this.validator(this.value);
                           ^

TypeError: this.validator is not a function
    at NumberPrompt.validate (.../node_modules/prompts/lib/elements/number.js:97:28)
    at NumberPrompt.submit (.../node_modules/prompts/lib/elements/number.js:106:16)
    at ReadStream.keypress (.../node_modules/prompts/lib/elements/prompt.js:32:16)
    at ReadStream.emit (node:events:515:28)
    at emitKeys (node:internal/readline/utils:371:14)
    at emitKeys.next (<anonymous>)
    at ReadStream.onData (node:internal/readline/emitKeypressEvents:64:36)
    at ReadStream.emit (node:events:527:35)
    at addChunk (node:internal/streams/readable:545:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:495:3)

Node.js v21.1.0
```

When I instead change the key to `validator` (vs `validate` as shown in the example) then everything works fine.

All tests are passing, so I made the assumption that it was the documentation that was wrong. If this assumption is incorrect please let me know. I find it odd that this has been around for 5 years without being reported? Is that correct? It concerns me that maybe I am missing context here.

Anyhow, I hope this helps. Accept or reject. I am just trying to help. :)