### PR TITLE
chore: add licenses badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,9 @@
   <a href="https://npmjs.org/package/prompts">
     <img src="https://img.shields.io/npm/dm/prompts.svg" alt="downloads" />
   </a>
+  <a href="https://licenses.dev/npm/prompts">
+    <img src="https://licenses.dev/b/npm/prompts" alt="licenses" />
+  </a>
   <!---
    <a href="https://packagephobia.now.sh/result?p=prompts">
     <img src="https://packagephobia.now.sh/badge?p=prompts" alt="install size" />


### PR DESCRIPTION
this service recursively checks the licenses of a package. in this case, prompts and all its dependencies (including indirects) use the MIT license, so the `MIT` value is displayed. this is a quick, easy way to display safety (green) of a dependency from a legal perspective 