### PR TITLE
Stop right arrow from selecting disabled choices

### DIFF
--- a/lib/elements/multiselect.js
+++ b/lib/elements/multiselect.js
@@ -125,8 +125,13 @@ class MultiselectPrompt extends Prompt {
   }
 
   right() {
-    if (this.value.filter(e => e.selected).length >= this.maxChoices) return this.bell();
-    this.value[this.cursor].selected = true;
+    const v = this.value[this.cursor];
+    const amountSelected =
+      this.value.filter((e) => e.selected).length >= this.maxChoices;
+    if (v.disabled || amountSelected >= this.maxChoices) {
+      return this.bell();
+    }
+    v.selected = true;
     this.render();
   }
 


### PR DESCRIPTION
Video of right arrow enabling a disabled choice in `example.js`:

https://github.com/terkelg/prompts/assets/8485687/b655791e-3281-449f-b0e9-5da0f29c9693