### PR TITLE
 Render autocomplete option description only when the option is hovered

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -219,7 +219,7 @@ class AutocompletePrompt extends Prompt {
     let prefix = isStart ? figures.arrowUp : isEnd ? figures.arrowDown : ' ';
     let title = hovered ? color.cyan().underline(v.title) : v.title;
     prefix = (hovered ? color.cyan(figures.pointer) + ' ' : '  ') + prefix;
-    if (v.description) {
+    if (v.description && hovered) {
       desc = ` - ${v.description}`;
       if (prefix.length + title.length + desc.length >= this.out.columns
         || v.description.split(/\r?\n/).length > 1) {


### PR DESCRIPTION
This keeps it consistent with how option descriptions are displayed in select and multiselect