### PR TITLE
feat: add `choices` support function

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -16,7 +16,7 @@ const getIndex = (arr, valOrTitle) => {
  * TextPrompt Base Element
  * @param {Object} opts Options
  * @param {String} opts.message Message
- * @param {Array} opts.choices Array of auto-complete choices objects
+ * @param {Array | (()=>Array) } opts.choices Array of choice objects or a function returning an array
  * @param {Function} [opts.suggest] Filter function. Defaults to sort by title
  * @param {Number} [opts.limit=10] Max number of results to show
  * @param {Number} [opts.cursor=0] Cursor start position
@@ -33,7 +33,7 @@ class AutocompletePrompt extends Prompt {
     super(opts);
     this.msg = opts.message;
     this.suggest = opts.suggest;
-    this.choices = opts.choices;
+    this.choices = typeof(opts.choices) === 'function' ?  opts.choices.call(this) : opts.choices;;
     this.initial = typeof opts.initial === 'number'
       ? opts.initial
       : getIndex(opts.choices, opts.initial);
@@ -102,7 +102,7 @@ class AutocompletePrompt extends Prompt {
     if (this.clearFirst && this.input.length > 0) {
       this.reset();
     } else {
-      this.done = this.exited = true; 
+      this.done = this.exited = true;
       this.aborted = false;
       this.fire();
       this.render();

--- a/lib/elements/autocompleteMultiselect.js
+++ b/lib/elements/autocompleteMultiselect.js
@@ -8,7 +8,7 @@ const { clear, style, figures } = require('../util');
  * MultiselectPrompt Base Element
  * @param {Object} opts Options
  * @param {String} opts.message Message
- * @param {Array} opts.choices Array of choice objects
+ * @param {Array | (()=>Array) } opts.choices Array of choice objects or a function returning an array
  * @param {String} [opts.hint] Hint to display
  * @param {String} [opts.warn] Hint shown for disabled choices
  * @param {Number} [opts.max] Max choices

--- a/lib/elements/multiselect.js
+++ b/lib/elements/multiselect.js
@@ -9,7 +9,7 @@ const { clear, figures, style, wrap, entriesToDisplay } = require('../util');
  * MultiselectPrompt Base Element
  * @param {Object} opts Options
  * @param {String} opts.message Message
- * @param {Array} opts.choices Array of choice objects
+ * @param {Array | (()=>Array) } opts.choices Array of choice objects or a function returning an array
  * @param {String} [opts.hint] Hint to display
  * @param {String} [opts.warn] Hint shown for disabled choices
  * @param {Number} [opts.max] Max choices
@@ -31,17 +31,18 @@ class MultiselectPrompt extends Prompt {
     this.maxChoices = opts.max;
     this.instructions = opts.instructions;
     this.optionsPerPage = opts.optionsPerPage || 10;
-    this.value = opts.choices.map((ch, idx) => {
-      if (typeof ch === 'string')
-        ch = {title: ch, value: idx};
-      return {
-        title: ch && (ch.title || ch.value || ch),
-        description: ch && ch.description,
-        value: ch && (ch.value === undefined ? idx : ch.value),
-        selected: ch && ch.selected,
-        disabled: ch && ch.disabled
-      };
-    });
+    const choices = typeof(opts.choices) === 'function' ?  opts.choices.call(this) : opts.choices;
+    this.value = choices.map((ch, idx) => {
+                  if (typeof ch === 'string')
+                    ch = {title: ch, value: idx};
+                  return {
+                    title: ch && (ch.title || ch.value || ch),
+                    description: ch && ch.description,
+                    value: ch && (ch.value === undefined ? idx : ch.value),
+                    selected: ch && ch.selected,
+                    disabled: ch && ch.disabled
+                  };
+                });
     this.clear = clear('', this.out.columns);
     if (!opts.overrideRender) {
       this.render();

--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -9,7 +9,7 @@ const { cursor } = require('sisteransi');
  * SelectPrompt Base Element
  * @param {Object} opts Options
  * @param {String} opts.message Message
- * @param {Array} opts.choices Array of choice objects
+ * @param {Array | (()=>Array) } opts.choices Array of choice objects or a function returning an array
  * @param {String} [opts.hint] Hint to display
  * @param {Number} [opts.initial] Index of default value
  * @param {Stream} [opts.stdin] The Readable stream to listen to
@@ -23,7 +23,8 @@ class SelectPrompt extends Prompt {
     this.hint = opts.hint || '- Use arrow-keys. Return to submit.';
     this.warn = opts.warn || '- This option is disabled';
     this.cursor = opts.initial || 0;
-    this.choices = opts.choices.map((ch, idx) => {
+    const choices = typeof(opts.choices) === 'function' ?  opts.choices.call(this) : opts.choices;
+    this.choices = choices.map((ch, idx) => {
       if (typeof ch === 'string')
         ch = {title: ch, value: idx};
       return {


### PR DESCRIPTION
prompt `Select`、`multiselect`、`autocomplete`、`autocompleteMultiselect` 's `choices` parameter supports functions
eg.

```diff
  const response = await prompts([
    {
      type: 'text',
      name: 'twitter',
      message: `What's your twitter handle?`
    },
    {
      type: 'multiselect',
      name: 'color',
      message: 'Pick colors',
+      choices: ()=>[                  
+           { title: 'Red', value: '#ff0000' },
+           { title: 'Green', value: '#00ff00' },
+           { title: 'Blue', value: '#0000ff' }
+       ],
    }
  ]);
```