### PR TITLE
fix(#338): now 'number' prompt type never renders '-Infinity' when pressing up or down arrows

### DIFF
--- a/lib/elements/number.js
+++ b/lib/elements/number.js
@@ -124,7 +124,7 @@ class NumberPrompt extends Prompt {
   up() {
     this.typed = ``;
     if(this.value === '') {
-      this.value = this.min - this.inc;
+      this.value = this.min === -Infinity ? 0 - this.inc : this.min - this.inc;
     }
     if (this.value >= this.max) return this.bell();
     this.value += this.inc;
@@ -136,7 +136,7 @@ class NumberPrompt extends Prompt {
   down() {
     this.typed = ``;
     if(this.value === '') {
-      this.value = this.min + this.inc;
+      this.value = this.min === -Infinity ? 0 + this.inc : this.min + this.inc;
     }
     if (this.value <= this.min) return this.bell();
     this.value -= this.inc;
@@ -150,7 +150,7 @@ class NumberPrompt extends Prompt {
     if (val.length === 0) return this.bell();
     this.value = this.parse((val = val.slice(0, -1))) || ``;
     if (this.value !== '' && this.value < this.min) {
-      this.value = this.min;
+      this.value = this.min === -Infinity ? 0 : this.min;
     }
     this.color = `cyan`;
     this.fire();


### PR DESCRIPTION
Related : https://github.com/terkelg/prompts/issues/338

I ran into a similar problem and it was anoying for my usage