### PR TITLE
Fix text prompt to prevent flashing on user input

### DIFF
--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -181,27 +181,46 @@ class TextPrompt extends Prompt {
 
   render() {
     if (this.closed) return;
+
+    let clearScreen = "";
     if (!this.firstRender) {
-      if (this.outputError)
-        this.out.write(cursor.down(lines(this.outputError, this.out.columns) - 1) + clear(this.outputError, this.out.columns));
-      this.out.write(clear(this.outputText, this.out.columns));
+      clearScreen += clear(this.outputText, this.out.columns);
+      if (this.outputError) {
+        clearScreen +=
+          cursor.down(lines(this.outputError, this.out.columns)) +
+          clear(this.outputError, this.out.columns);
+      }
     }
-    super.render();
-    this.outputError = '';
 
     this.outputText = [
       style.symbol(this.done, this.aborted),
       color.bold(this.msg),
       style.delimiter(this.done),
-      this.red ? color.red(this.rendered) : this.rendered
-    ].join(` `);
+      this.red ? color.red(this.rendered) : this.rendered,
+    ].join(" ");
 
     if (this.error) {
-      this.outputError += this.errorMsg.split(`\n`)
-          .reduce((a, l, i) => a + `\n${i ? ' ' : figures.pointerSmall} ${color.red().italic(l)}`, ``);
+      const lines = this.errorMsg
+        .split("\n")
+        .map((line) => `  ${color.red().italic(line)}`);
+
+      this.outputError = `\n${figures.pointerSmall}${lines.join("\n")}`;
+    } else {
+      this.outputError = "";
     }
 
-    this.out.write(erase.line + cursor.to(0) + this.outputText + cursor.save + this.outputError + cursor.restore + cursor.move(this.cursorOffset, 0));
+    this.out.write(
+      clearScreen +
+        erase.line +
+        cursor.to(0) +
+        this.outputText +
+        cursor.save +
+        this.outputError +
+        cursor.restore +
+        cursor.move(this.cursorOffset, 0)
+    );
+
+    super.render();
   }
 }
 

--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -211,13 +211,13 @@ class TextPrompt extends Prompt {
 
     this.out.write(
       clearScreen +
-        erase.line +
-        cursor.to(0) +
-        this.outputText +
-        cursor.save +
-        this.outputError +
-        cursor.restore +
-        cursor.move(this.cursorOffset, 0)
+      erase.line +
+      cursor.to(0) +
+      this.outputText +
+      cursor.save +
+      this.outputError +
+      cursor.restore +
+      cursor.move(this.cursorOffset, 0)
     );
 
     super.render();


### PR DESCRIPTION
- Clean up render method for the text prompt to use a single `write` so the prompt doesn't flash during user input.
- Fix cleanup of error messages that have more than 1 line.

### Note:
If this gets merged I'll create a follow up PR for the remaining prompts since most of them suffer from the same problems