### PR TITLE
feat: add param "optionsPerPage" into interface "PromptObject"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,9 +63,9 @@ declare namespace prompts {
 	interface Choice {
 		title: string;
 		value?: any;
-		disabled?: boolean | undefined;
-		selected?: boolean | undefined;
-		description?: string | undefined;
+		disabled?: boolean;
+		selected?: boolean;
+		description?: string;
 	}
 
 	interface Options {
@@ -73,33 +73,34 @@ declare namespace prompts {
 		onCancel?: ((prompt: PromptObject, answers: any) => void) | undefined;
 	}
 
-	interface PromptObject<T extends string = string> {
-		type: PromptType | Falsy | PrevCaller<T, PromptType | Falsy>;
+	interface PromptObject<T extends string = string, R extends PromptType | Falsy | PrevCaller<T, PromptType | Falsy> = null> {
+		type: R;
 		name: ValueOrFunc<T>;
-		message?: ValueOrFunc<string> | undefined;
-		initial?: InitialReturnValue | PrevCaller<T, InitialReturnValue | Promise<InitialReturnValue>> | undefined;
-		style?: string | PrevCaller<T, string | Falsy> | undefined;
-		format?: PrevCaller<T, void> | undefined;
-		validate?: PrevCaller<T, boolean | string | Promise<boolean | string>> | undefined;
+		message?: ValueOrFunc<string>;
+		initial?: InitialReturnValue | PrevCaller<T, InitialReturnValue | Promise<InitialReturnValue>>;
+		style?: string | PrevCaller<T, string | Falsy>;
+		format?: PrevCaller<T, void>;
+		validate?: PrevCaller<T, boolean | string | Promise<boolean | string>>;
 		onState?: PrevCaller<T, void> | undefined;
-		onRender?: ((kleur: Kleur) => void) | undefined;
-		min?: number | PrevCaller<T, number | Falsy> | undefined;
-		max?: number | PrevCaller<T, number | Falsy> | undefined;
-		float?: boolean | PrevCaller<T, boolean | Falsy> | undefined;
-		round?: number | PrevCaller<T, number | Falsy> | undefined;
-		instructions?: string | boolean | undefined;
-		increment?: number | PrevCaller<T, number | Falsy> | undefined;
-		separator?: string | PrevCaller<T, string | Falsy> | undefined;
-		active?: string | PrevCaller<T, string | Falsy> | undefined;
-		inactive?: string | PrevCaller<T, string | Falsy> | undefined;
-		choices?: Choice[] | PrevCaller<T, Choice[] | Falsy> | undefined;
-		hint?: string | PrevCaller<T, string | Falsy> | undefined;
-		warn?: string | PrevCaller<T, string | Falsy> | undefined;
-		suggest?: ((input: any, choices: Choice[]) => Promise<any>) | undefined;
-		limit?: number | PrevCaller<T, number | Falsy> | undefined;
-		mask?: string | PrevCaller<T, string | Falsy> | undefined;
-		stdout?: Writable | undefined;
-		stdin?: Readable | undefined;
+		onRender?: ((kleur: Kleur) => void);
+		min?: number | PrevCaller<T, number | Falsy>;
+		max?: number | PrevCaller<T, number | Falsy>;
+		float?: boolean | PrevCaller<T, boolean | Falsy>;
+		round?: number | PrevCaller<T, number | Falsy>;
+		instructions?: string | boolean;
+		increment?: number | PrevCaller<T, number | Falsy>;
+		separator?: string | PrevCaller<T, string | Falsy>;
+		active?: string | PrevCaller<T, string | Falsy>;
+		inactive?: string | PrevCaller<T, string | Falsy>;
+		choices?: Choice[] | PrevCaller<T, Choice[] | Falsy>;
+		hint?: string | PrevCaller<T, string | Falsy>;
+		warn?: string | PrevCaller<T, string | Falsy>;
+		suggest?: ((input: any, choices: Choice[]) => Promise<any>);
+		limit?: number | PrevCaller<T, number | Falsy>;
+		mask?: string | PrevCaller<T, string | Falsy>;
+		optionsPerPage?: number;
+		stdout?: Writable;
+		stdin?: Readable;
 	}
 
 	type Answers<T extends string> = { [id in T]: any };


### PR DESCRIPTION
There's a param "optionsPerPage" on type "multiselect" & "autocompleteMultiselect", but not declared in the type define. Here's a PR to solve it.