### PR TITLE
fix: prevent crash when toggling selection with empty filter results

### DIFF
--- a/lib/elements/autocompleteMultiselect.js
+++ b/lib/elements/autocompleteMultiselect.js
@@ -54,11 +54,13 @@ class AutocompleteMultiselectPrompt extends MultiselectPrompt {
   }
 
   left() {
+    if (this.filteredOptions.length === 0) return this.bell();
     this.filteredOptions[this.cursor].selected = false;
     this.render();
   }
 
   right() {
+    if (this.filteredOptions.length === 0) return this.bell();
     if (this.value.filter(e => e.selected).length >= this.maxChoices) return this.bell();
     this.filteredOptions[this.cursor].selected = true;
     this.render();
@@ -97,6 +99,10 @@ class AutocompleteMultiselectPrompt extends MultiselectPrompt {
 
   handleSpaceToggle() {
     const v = this.filteredOptions[this.cursor];
+
+    if (v === undefined) {
+      return this.bell();
+    }
 
     if (v.selected) {
       v.selected = false;

--- a/test/autocompleteMultiselect.js
+++ b/test/autocompleteMultiselect.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const test = require('tape');
+const { Writable, Readable } = require('stream');
+const AutocompleteMultiselectPrompt = require('../lib/elements/autocompleteMultiselect');
+
+// Mock stdin that doesn't need TTY
+class MockStdin extends Readable {
+  constructor() {
+    super();
+    this.isTTY = false;
+  }
+  _read() {}
+  setRawMode() {}
+}
+
+// Mock stdout that captures output
+class MockStdout extends Writable {
+  constructor() {
+    super();
+    this.output = '';
+    this.columns = 80;
+  }
+  _write(chunk, encoding, callback) {
+    this.output += chunk.toString();
+    callback();
+  }
+}
+
+test('autocompleteMultiselect - handleSpaceToggle with empty filtered options', t => {
+  t.plan(1);
+
+  const stdin = new MockStdin();
+  const stdout = new MockStdout();
+
+  const prompt = new AutocompleteMultiselectPrompt({
+    message: 'Test',
+    choices: [
+      { title: 'Foo', value: 'Foo' }
+    ],
+    stdin,
+    stdout
+  });
+
+  // Simulate filtering that produces no results
+  prompt.inputValue = 'xyz'; // No match
+  prompt.updateFilteredOptions();
+
+  // This should not throw - it should just bell()
+  try {
+    prompt.handleSpaceToggle();
+    t.pass('handleSpaceToggle does not throw with empty filtered options');
+  } catch (e) {
+    t.fail(`handleSpaceToggle threw error: ${e.message}`);
+  }
+
+  prompt.close();
+});
+
+test('autocompleteMultiselect - left() with empty filtered options', t => {
+  t.plan(1);
+
+  const stdin = new MockStdin();
+  const stdout = new MockStdout();
+
+  const prompt = new AutocompleteMultiselectPrompt({
+    message: 'Test',
+    choices: [
+      { title: 'Foo', value: 'Foo' }
+    ],
+    stdin,
+    stdout
+  });
+
+  // Simulate filtering that produces no results
+  prompt.inputValue = 'xyz'; // No match
+  prompt.updateFilteredOptions();
+
+  // This should not throw - it should just bell()
+  try {
+    prompt.left();
+    t.pass('left() does not throw with empty filtered options');
+  } catch (e) {
+    t.fail(`left() threw error: ${e.message}`);
+  }
+
+  prompt.close();
+});
+
+test('autocompleteMultiselect - right() with empty filtered options', t => {
+  t.plan(1);
+
+  const stdin = new MockStdin();
+  const stdout = new MockStdout();
+
+  const prompt = new AutocompleteMultiselectPrompt({
+    message: 'Test',
+    choices: [
+      { title: 'Foo', value: 'Foo' }
+    ],
+    stdin,
+    stdout
+  });
+
+  // Simulate filtering that produces no results
+  prompt.inputValue = 'xyz'; // No match
+  prompt.updateFilteredOptions();
+
+  // This should not throw - it should just bell()
+  try {
+    prompt.right();
+    t.pass('right() does not throw with empty filtered options');
+  } catch (e) {
+    t.fail(`right() threw error: ${e.message}`);
+  }
+
+  prompt.close();
+});
+
+test('autocompleteMultiselect - space toggle still works with valid options', t => {
+  t.plan(2);
+
+  const stdin = new MockStdin();
+  const stdout = new MockStdout();
+
+  const prompt = new AutocompleteMultiselectPrompt({
+    message: 'Test',
+    choices: [
+      { title: 'Foo', value: 'Foo' },
+      { title: 'Bar', value: 'Bar' }
+    ],
+    stdin,
+    stdout
+  });
+
+  // Should have all options available initially
+  t.equal(prompt.filteredOptions.length, 2, 'has 2 filtered options initially');
+
+  // Toggle selection - should not throw and should select the item
+  prompt.handleSpaceToggle();
+  t.equal(prompt.filteredOptions[0].selected, true, 'first option is selected after space toggle');
+
+  prompt.close();
+});


### PR DESCRIPTION
## Summary

Fixes #418

When using `autocompleteMultiselect` prompt, pressing space, left, or right arrow keys to toggle selection when there are no filtered results causes a crash:

```
TypeError: Cannot read properties of undefined (reading 'selected')
    at AutocompleteMultiselectPrompt.handleSpaceToggle (node_modules/prompts/lib/elements/autocompleteMultiselect.js:101:10)
```

## Root Cause

When the user types a filter query that matches no choices, `this.filteredOptions` becomes an empty array. The `handleSpaceToggle()`, `left()`, and `right()` methods try to access `this.filteredOptions[this.cursor]` without checking if the array is empty, resulting in `undefined` access.

## Solution

Added guards to prevent the crash:

- **`handleSpaceToggle()`**: Check if the item at cursor is `undefined` before accessing `.selected`
- **`left()`**: Check if `filteredOptions.length === 0` before accessing
- **`right()`**: Check if `filteredOptions.length === 0` before accessing

When the filter produces no results, these methods now call `this.bell()` to provide audio feedback instead of crashing.

## Reproduction

```javascript
import prompts from 'prompts';

await prompts({
    type: 'autocompleteMultiselect',
    name: 'test',
    message: 'Enter some gibberish below, then press space',
    choices: [
        { title: 'Foo', value: 'Foo' },
    ],
});
```

Type any text that doesn't match "Foo", then press space. Before this fix, it crashes. After this fix, it beeps.

## Test Plan

- Added new test file `test/autocompleteMultiselect.js` with tests for:
  - `handleSpaceToggle()` with empty filtered options
  - `left()` with empty filtered options  
  - `right()` with empty filtered options
  - Verifying normal operation still works when options are available

All 55 tests pass (50 existing + 5 new).