### PR TITLE
fix(confirm): guard against non-string key in keypress handler

### DIFF
--- a/lib/elements/confirm.js
+++ b/lib/elements/confirm.js
@@ -57,6 +57,7 @@ class ConfirmPrompt extends Prompt {
   }
 
   _(c, key) {
+    if (typeof c !== 'string') return this.bell();
     if (c.toLowerCase() === 'y') {
       this.value = true;
       return this.submit();

--- a/test/confirm.js
+++ b/test/confirm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const test = require('tape');
+const ConfirmPrompt = require('../lib/elements/confirm');
+
+test('does not crash on non-string key (e.g. function keys)', (t) => {
+  t.plan(1);
+  const confirmPrompt = new ConfirmPrompt({ message: 'x' });
+  t.doesNotThrow(() => confirmPrompt._(undefined, { name: 'f2' }), 'undefined character handled');
+  confirmPrompt.close();
+});
+
+test('accepts "y" to submit true', (t) => {
+  t.plan(2);
+  const confirmPrompt = new ConfirmPrompt({ message: 'x' });
+  confirmPrompt._('y', { name: 'y' });
+  t.equal(confirmPrompt.value, true, 'value is true after pressing y');
+  t.equal(confirmPrompt.done, true, 'prompt is done after pressing y');
+});
+
+test('accepts "n" to submit false', (t) => {
+  t.plan(2);
+  const confirmPrompt = new ConfirmPrompt({ message: 'x' });
+  confirmPrompt._('n', { name: 'n' });
+  t.equal(confirmPrompt.value, false, 'value is false after pressing n');
+  t.equal(confirmPrompt.done, true, 'prompt is done after pressing n');
+});


### PR DESCRIPTION
Pressing function keys (F1, F2, etc.) inside a `confirm` prompt crashes with `Cannot read properties of undefined (reading 'toLowerCase')` because the keypress `str` argument is `undefined` for those keys. Skip the comparison and beep instead, matching the existing fallback behavior.

Closes #404