### PR TITLE
fix(#260): do not print "undefined" for Ins and unrecognized keys

### DIFF
--- a/lib/elements/prompt.js
+++ b/lib/elements/prompt.js
@@ -26,7 +26,7 @@ class Prompt extends EventEmitter {
     const isSelect = [ 'SelectPrompt', 'MultiselectPrompt' ].indexOf(this.constructor.name) > -1;
     const keypress = (str, key) => {
       let a = action(key, isSelect);
-      if (a === false) {
+      if (a === false && typeof str === 'string') {
         this._ && this._(str, key);
       } else if (typeof this[a] === 'function') {
         this[a](key);

--- a/test/text.js
+++ b/test/text.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { PassThrough } = require('stream');
 const test = require('tape');
 const TextPrompt = require('../lib/elements/text');
 
@@ -57,3 +58,25 @@ test('submit', (t) => {
   t.same(textPrompt.cursorOffset, 0, 'cursorOffset is reset on submit')
   t.same(textPrompt.cursor, textPrompt.rendered.length, 'cursor is reset to end of line on submit')
 })
+
+test('unrecognized keys', (t) => {
+  t.plan(3);
+
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const textPrompt = new TextPrompt({ stdin, stdout, message: 'test' });
+  textPrompt.value = 'hello';
+  textPrompt.last();
+
+  stdin.emit('keypress', undefined, { name: 'insert', ctrl: false, meta: false, shift: false });
+  t.equal(textPrompt.value, 'hello', 'insert key does not append undefined');
+
+  stdin.emit('keypress', undefined, { name: 'f1', ctrl: false, meta: false, shift: false });
+  t.equal(textPrompt.value, 'hello', 'f1 key does not append undefined');
+
+  stdin.emit('keypress', '!', { name: '!', ctrl: false, meta: false, shift: false });
+  t.equal(textPrompt.value, 'hello!', 'printable characters are still accepted');
+
+  textPrompt.submit();
+  t.end();
+});


### PR DESCRIPTION
The keypress dispatcher in `lib/elements/prompt.js` only calls the character handler when `str` is a string. Ins and unhandled F-keys arrive from Node's readline with `str === undefined` and a named `key`. `action()` returns `false` for anything it does not map, and the dispatcher called `_` anyway, so `` `${undefined}` `` became the string `"undefined"`. The same interpolation exists on autocomplete, and confirm would throw via `c.toLowerCase()`.

Unmapped non-string keypresses take the existing `bell()` path. Printable characters are unchanged.

The other option is to map `insert` and `f1`-`f12` in `action.js`, the same pattern as Home/End in #247, Del in #90, and Alt in #164. Listing keys is why this class of bug kept coming back. A non-string `str` is not input. The issue asks that unrecognized keys not print, not that Ins/F-keys be named. Can switch to action-table mappings.

Fixes #260

## Test plan

- [x] `npx tape test/text.js`
- [ ] Text prompt: type normally, then press Ins / F1-F12. Value must not become "undefined"
- [ ] Autocomplete: same keys must not append "undefined" to the filter
